### PR TITLE
Updating flake inputs Wed Mar 12 00:57:29 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1741370365,
-        "narHash": "sha256-p8LTd7ofbPJvkES5uEzRpoBzgm3QF/3ntOyy8RJ8Gvo=",
+        "lastModified": 1741482962,
+        "narHash": "sha256-vCQrmxLw+xgytWR7+cyGdYYV22Jb8iTC9/pbtyJSOX0=",
         "owner": "vic",
         "repo": "SPC",
-        "rev": "d7368a8c16a4844dbac191265d20d03c269696a6",
+        "rev": "c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741217763,
-        "narHash": "sha256-g/TrltIjFHIjtzKY5CJpoPANfHQWDD43G5U1a/v5oVg=",
+        "lastModified": 1741701235,
+        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "486b066025dccd8af7fbe5dd2cc79e46b88c80da",
+        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740886574,
-        "narHash": "sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk=",
+        "lastModified": 1741619381,
+        "narHash": "sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "26a0f969549cf4d56f6e9046b9e0418b3f3b94a5",
+        "rev": "66537fb185462ba9b07f4e6f2d54894a1b2d04ab",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741037377,
-        "narHash": "sha256-SvtvVKHaUX4Owb+PasySwZsoc5VUeTf1px34BByiOxw=",
+        "lastModified": 1741708242,
+        "narHash": "sha256-cNRqdQD4sZpN7JLqxVOze4+WsWTmv2DGH0wNCOVwrWc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "02032da4af073d0f6110540c8677f16d4be0117f",
+        "rev": "b62d2a95c72fb068aecd374a7262b37ed92df82b",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741043164,
-        "narHash": "sha256-9lfmSZLz6eq9Ygr6cCmvQiiBEaPb54pUBcjvbEMPORc=",
+        "lastModified": 1741644481,
+        "narHash": "sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn+iZajOyg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3f2412536eeece783f0d0ad3861417f347219f4d",
+        "rev": "e653d71e82575a43fe9d228def8eddb73887b866",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741312999,
-        "narHash": "sha256-lCqSUY3gxigQfsL8cAKBXn7vO/+JfHfdfuR9P9hi7JE=",
+        "lastModified": 1741354009,
+        "narHash": "sha256-+zXgbNiN9Cwnd/21vY7Wo31/gkyKUbaoXHIx65KY79o=",
         "owner": "vic",
         "repo": "use_devshell_toml",
-        "rev": "2bbf9af59edaba51b047c372a3e708ee78304d04",
+        "rev": "63f65adffe7d94a237552451bd70b10372492dab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Mar 12 00:57:29 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:numtide/devshell/7c9e793ebe66bcba8292989a68c0419b737a22a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/8846d151814ebbf7fb90d9d5dd16cd737257408e' into the Git cache...
unpacking 'github:nix-community/home-manager/c630dfa8abcc65984cc1e47fb25d4552c81dd37e' into the Git cache...
unpacking 'github:LnL7/nix-darwin/adf5c88ba1fe21af5c083b4d655004431f20c5ab' into the Git cache...
unpacking 'github:nix-community/nix-index-database/66537fb185462ba9b07f4e6f2d54894a1b2d04ab' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/0e4ccdb8181da2c6193c047b50ffee5f1a3b6dc1' into the Git cache...
unpacking 'github:nixos/nixpkgs/b62d2a95c72fb068aecd374a7262b37ed92df82b' into the Git cache...
unpacking 'github:madsbv/nix-options-search/e2d08049d898a272f55c4e218544a04f0d314fad' into the Git cache...
unpacking 'github:Mic92/sops-nix/e653d71e82575a43fe9d228def8eddb73887b866' into the Git cache...
unpacking 'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'SPC':
    'github:vic/SPC/d7368a8c16a4844dbac191265d20d03c269696a6?narHash=sha256-p8LTd7ofbPJvkES5uEzRpoBzgm3QF/3ntOyy8RJ8Gvo%3D' (2025-03-07)
  → 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0?narHash=sha256-vCQrmxLw%2BxgytWR7%2BcyGdYYV22Jb8iTC9/pbtyJSOX0%3D' (2025-03-09)
• Updated input 'devshell':
    'github:numtide/devshell/f7795ede5b02664b57035b3b757876703e2c3eac?narHash=sha256-tO3HrHriyLvipc4xr%2BEwtdlo7wM1OjXNjlWRgmM7peY%3D' (2024-12-31)
  → 'github:numtide/devshell/7c9e793ebe66bcba8292989a68c0419b737a22a0?narHash=sha256-kWNaq6wQUbUMlPgw8Y%2B9/9wP0F8SHkjy24/mN3UAppg%3D' (2025-03-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/486b066025dccd8af7fbe5dd2cc79e46b88c80da?narHash=sha256-g/TrltIjFHIjtzKY5CJpoPANfHQWDD43G5U1a/v5oVg%3D' (2025-03-05)
  → 'github:nix-community/home-manager/c630dfa8abcc65984cc1e47fb25d4552c81dd37e?narHash=sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3%2B91651y3Sqo%3D' (2025-03-11)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/26a0f969549cf4d56f6e9046b9e0418b3f3b94a5?narHash=sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk%3D' (2025-03-02)
  → 'github:nix-community/nix-index-database/66537fb185462ba9b07f4e6f2d54894a1b2d04ab?narHash=sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE%3D' (2025-03-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/02032da4af073d0f6110540c8677f16d4be0117f?narHash=sha256-SvtvVKHaUX4Owb%2BPasySwZsoc5VUeTf1px34BByiOxw%3D' (2025-03-03)
  → 'github:nixos/nixpkgs/b62d2a95c72fb068aecd374a7262b37ed92df82b?narHash=sha256-cNRqdQD4sZpN7JLqxVOze4%2BWsWTmv2DGH0wNCOVwrWc%3D' (2025-03-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/3f2412536eeece783f0d0ad3861417f347219f4d?narHash=sha256-9lfmSZLz6eq9Ygr6cCmvQiiBEaPb54pUBcjvbEMPORc%3D' (2025-03-03)
  → 'github:Mic92/sops-nix/e653d71e82575a43fe9d228def8eddb73887b866?narHash=sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn%2BiZajOyg%3D' (2025-03-10)
• Updated input 'use_devshell_toml':
    'github:vic/use_devshell_toml/2bbf9af59edaba51b047c372a3e708ee78304d04?narHash=sha256-lCqSUY3gxigQfsL8cAKBXn7vO/%2BJfHfdfuR9P9hi7JE%3D' (2025-03-07)
  → 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab?narHash=sha256-%2BzXgbNiN9Cwnd/21vY7Wo31/gkyKUbaoXHIx65KY79o%3D' (2025-03-07)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
