### PR TITLE
Updating flake inputs Thu Mar 13 05:14:43 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -140,11 +140,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1741115618,
-        "narHash": "sha256-3a1cfxzaM/jvrrODgYdxyji9KN0rQZjPJzgPFNRiBIw=",
+        "lastModified": 1741842488,
+        "narHash": "sha256-bqqnkoXND8Sfc2MnTIKBRQSYed0fjgMn481wiIhwyz4=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "8846d151814ebbf7fb90d9d5dd16cd737257408e",
+        "rev": "c95015d7066476d32784c6f0ed7463b92b931bec",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741701235,
-        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
+        "lastModified": 1741791118,
+        "narHash": "sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
+        "rev": "18780912345970e5b546b1b085385789b6935a83",
         "type": "github"
       },
       "original": {
@@ -249,11 +249,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741229100,
-        "narHash": "sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs=",
+        "lastModified": 1741794429,
+        "narHash": "sha256-4J46D8sOZ3UroVyGYKYMU3peq9gv0tjRX0KbZihWhhw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "adf5c88ba1fe21af5c083b4d655004431f20c5ab",
+        "rev": "2fb6b09b678a1ab258cf88e3ea4a966edceec6a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Mar 13 05:14:43 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/c95015d7066476d32784c6f0ed7463b92b931bec' into the Git cache...
unpacking 'github:nix-community/home-manager/18780912345970e5b546b1b085385789b6935a83' into the Git cache...
unpacking 'github:LnL7/nix-darwin/2fb6b09b678a1ab258cf88e3ea4a966edceec6a8' into the Git cache...
unpacking 'github:nix-community/nix-index-database/66537fb185462ba9b07f4e6f2d54894a1b2d04ab' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/0e4ccdb8181da2c6193c047b50ffee5f1a3b6dc1' into the Git cache...
unpacking 'github:nixos/nixpkgs/b62d2a95c72fb068aecd374a7262b37ed92df82b' into the Git cache...
unpacking 'github:madsbv/nix-options-search/e2d08049d898a272f55c4e218544a04f0d314fad' into the Git cache...
unpacking 'github:Mic92/sops-nix/e653d71e82575a43fe9d228def8eddb73887b866' into the Git cache...
unpacking 'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/8846d151814ebbf7fb90d9d5dd16cd737257408e?narHash=sha256-3a1cfxzaM/jvrrODgYdxyji9KN0rQZjPJzgPFNRiBIw%3D' (2025-03-04)
  → 'github:doomemacs/doomemacs/c95015d7066476d32784c6f0ed7463b92b931bec?narHash=sha256-bqqnkoXND8Sfc2MnTIKBRQSYed0fjgMn481wiIhwyz4%3D' (2025-03-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c630dfa8abcc65984cc1e47fb25d4552c81dd37e?narHash=sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3%2B91651y3Sqo%3D' (2025-03-11)
  → 'github:nix-community/home-manager/18780912345970e5b546b1b085385789b6935a83?narHash=sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA%3D' (2025-03-12)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/adf5c88ba1fe21af5c083b4d655004431f20c5ab?narHash=sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs%3D' (2025-03-06)
  → 'github:LnL7/nix-darwin/2fb6b09b678a1ab258cf88e3ea4a966edceec6a8?narHash=sha256-4J46D8sOZ3UroVyGYKYMU3peq9gv0tjRX0KbZihWhhw%3D' (2025-03-12)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
