### PR TITLE
Updating flake inputs Fri Mar 14 03:57:42 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,11 +4,15 @@
       "inputs": {
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
-        "blueprint": "blueprint",
+        "blueprint": [
+          "blueprint"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
       },
       "locked": {
         "lastModified": 1741482962,
@@ -59,31 +63,11 @@
     "blueprint": {
       "inputs": {
         "nixpkgs": [
-          "SPC",
           "nixpkgs"
         ],
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1741365449,
-        "narHash": "sha256-4bmMbrmc6p6QxmF0Frc6SoZUfaodWcxjqEgw5mGmTAQ=",
-        "owner": "numtide",
-        "repo": "blueprint",
-        "rev": "09a2c2c7bb08e5baeb88319e042ccfe6acaa9664",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "blueprint",
-        "type": "github"
-      }
-    },
-    "blueprint_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": "systems_2"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1741697533,
@@ -171,7 +155,9 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -179,24 +165,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -324,7 +292,9 @@
     },
     "nox": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -348,10 +318,11 @@
     "root": {
       "inputs": {
         "SPC": "SPC",
-        "blueprint": "blueprint_2",
+        "blueprint": "blueprint",
         "cli-leader": "cli-leader",
         "devshell": "devshell",
         "doom-emacs": "doom-emacs",
+        "flake-utils": "flake-utils",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",
@@ -359,8 +330,8 @@
         "nixpkgs": "nixpkgs",
         "nox": "nox",
         "sops-nix": "sops-nix",
-        "systems": "systems_4",
-        "treefmt-nix": "treefmt-nix_2",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix",
         "use_devshell_toml": "use_devshell_toml",
         "vscode-server": "vscode-server"
       }
@@ -397,93 +368,12 @@
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
         "ref": "main",
         "repo": "default",
         "type": "github"
       }
     },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "SPC",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -528,7 +418,9 @@
     },
     "vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741791118,
-        "narHash": "sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA=",
+        "lastModified": 1741914680,
+        "narHash": "sha256-Vu4DIZvgfWMzhUyxbHUrJaQb5232S5vuwxQ2sBcBVHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18780912345970e5b546b1b085385789b6935a83",
+        "rev": "30cce6848a5aa41ceb5fb33185b84868cc3e9bef",
         "type": "github"
       },
       "original": {
@@ -249,11 +249,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741794429,
-        "narHash": "sha256-4J46D8sOZ3UroVyGYKYMU3peq9gv0tjRX0KbZihWhhw=",
+        "lastModified": 1741906019,
+        "narHash": "sha256-c9L0yCdpBzPVTcExcqTti6vP6GuPVaCaVCDf0M8eu+I=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2fb6b09b678a1ab258cf88e3ea4a966edceec6a8",
+        "rev": "4d8a451649b6de429ea7e169378488305d0d9399",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741192150,
-        "narHash": "sha256-wB140alXVla1Rw/kENerUoma2qO1Jy5IYWbmiSqmJu0=",
+        "lastModified": 1741870048,
+        "narHash": "sha256-odXRdNZGdXg1LmwlAeWL85kgy/FVHsgKlDwrvbR2BsU=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "0e4ccdb8181da2c6193c047b50ffee5f1a3b6dc1",
+        "rev": "5d76001e33ee19644a598ad80e7318ab0957b122",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741708242,
-        "narHash": "sha256-cNRqdQD4sZpN7JLqxVOze4+WsWTmv2DGH0wNCOVwrWc=",
+        "lastModified": 1741865919,
+        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b62d2a95c72fb068aecd374a7262b37ed92df82b",
+        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
         "type": "github"
       },
       "original": {
@@ -331,11 +331,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740418382,
-        "narHash": "sha256-kLncL2qxB29i6+ikkeIYfDkqtBjdhXvrEYyENbpSB7Q=",
+        "lastModified": 1741914482,
+        "narHash": "sha256-bDrZUOuzPaNhvyeLwKq/FeauAT2HXeZquaM3Qm4wbuw=",
         "owner": "madsbv",
         "repo": "nix-options-search",
-        "rev": "e2d08049d898a272f55c4e218544a04f0d314fad",
+        "rev": "fad08278c264f5bfd26141522b8910413c77fd7c",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741644481,
-        "narHash": "sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn+iZajOyg=",
+        "lastModified": 1741861888,
+        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e653d71e82575a43fe9d228def8eddb73887b866",
+        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,13 @@
 
     systems.url = "github:nix-systems/default?ref=main&shallow=1";
 
+    # not used here but followed by other deps to get a flat dep tree
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.inputs.systems.follows = "systems";
+
     blueprint.url = "github:numtide/blueprint?shallow=1";
     blueprint.inputs.nixpkgs.follows = "nixpkgs";
+    blueprint.inputs.systems.follows = "systems";
 
     nix-darwin.url = "github:LnL7/nix-darwin?ref=master&shallow=1";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
@@ -28,12 +33,14 @@
 
     vscode-server.url = "github:nix-community/nixos-vscode-server?ref=master&shallow=1";
     vscode-server.inputs.nixpkgs.follows = "nixpkgs";
+    vscode-server.inputs.flake-utils.follows = "flake-utils";
 
     cli-leader.url = "github:dhamidi/leader?ref=14373a2&shallow=1";
     cli-leader.flake = false;
 
     nox.url = "github:madsbv/nix-options-search?ref=main&shallow=1";
     nox.inputs.nixpkgs.follows = "nixpkgs";
+    nox.inputs.flake-utils.follows = "flake-utils";
 
     devshell.url = "github:numtide/devshell?ref=main&shallow=1";
     devshell.inputs.nixpkgs.follows = "nixpkgs";
@@ -53,6 +60,8 @@
 
     SPC.url = "github:vic/SPC";
     SPC.inputs.nixpkgs.follows = "nixpkgs";
+    SPC.inputs.blueprint.follows = "blueprint";
+    SPC.inputs.treefmt-nix.follows = "treefmt-nix";
 
     doom-emacs.url = "github:doomemacs/doomemacs";
     doom-emacs.flake = false;


### PR DESCRIPTION
Updating flake inputs Fri Mar 14 03:57:42 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/c95015d7066476d32784c6f0ed7463b92b931bec' into the Git cache...
unpacking 'github:nix-community/home-manager/30cce6848a5aa41ceb5fb33185b84868cc3e9bef' into the Git cache...
unpacking 'github:LnL7/nix-darwin/4d8a451649b6de429ea7e169378488305d0d9399' into the Git cache...
unpacking 'github:nix-community/nix-index-database/66537fb185462ba9b07f4e6f2d54894a1b2d04ab' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/5d76001e33ee19644a598ad80e7318ab0957b122' into the Git cache...
unpacking 'github:nixos/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f' into the Git cache...
unpacking 'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/18780912345970e5b546b1b085385789b6935a83?narHash=sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA%3D' (2025-03-12)
  → 'github:nix-community/home-manager/30cce6848a5aa41ceb5fb33185b84868cc3e9bef?narHash=sha256-Vu4DIZvgfWMzhUyxbHUrJaQb5232S5vuwxQ2sBcBVHk%3D' (2025-03-14)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/2fb6b09b678a1ab258cf88e3ea4a966edceec6a8?narHash=sha256-4J46D8sOZ3UroVyGYKYMU3peq9gv0tjRX0KbZihWhhw%3D' (2025-03-12)
  → 'github:LnL7/nix-darwin/4d8a451649b6de429ea7e169378488305d0d9399?narHash=sha256-c9L0yCdpBzPVTcExcqTti6vP6GuPVaCaVCDf0M8eu%2BI%3D' (2025-03-13)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/0e4ccdb8181da2c6193c047b50ffee5f1a3b6dc1?narHash=sha256-wB140alXVla1Rw/kENerUoma2qO1Jy5IYWbmiSqmJu0%3D' (2025-03-05)
  → 'github:nix-community/nixos-wsl/5d76001e33ee19644a598ad80e7318ab0957b122?narHash=sha256-odXRdNZGdXg1LmwlAeWL85kgy/FVHsgKlDwrvbR2BsU%3D' (2025-03-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b62d2a95c72fb068aecd374a7262b37ed92df82b?narHash=sha256-cNRqdQD4sZpN7JLqxVOze4%2BWsWTmv2DGH0wNCOVwrWc%3D' (2025-03-11)
  → 'github:nixos/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a?narHash=sha256-4thdbnP6dlbdq%2BqZWTsm4ffAwoS8Tiq1YResB%2BRP6WE%3D' (2025-03-13)
• Updated input 'nox':
    'github:madsbv/nix-options-search/e2d08049d898a272f55c4e218544a04f0d314fad?narHash=sha256-kLncL2qxB29i6%2BikkeIYfDkqtBjdhXvrEYyENbpSB7Q%3D' (2025-02-24)
  → 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c?narHash=sha256-bDrZUOuzPaNhvyeLwKq/FeauAT2HXeZquaM3Qm4wbuw%3D' (2025-03-14)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/e653d71e82575a43fe9d228def8eddb73887b866?narHash=sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn%2BiZajOyg%3D' (2025-03-10)
  → 'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f?narHash=sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0%3D' (2025-03-13)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
