### PR TITLE
Updating flake inputs Sat Mar 15 05:13:41 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741697533,
-        "narHash": "sha256-+4vOgmO/RLRW7VQyL+ua5Q/sKZbp3Cg9IumqWlOcuK4=",
+        "lastModified": 1741947577,
+        "narHash": "sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "658dfdb19eab4766270ffd20f36c55dc7dc8ed30",
+        "rev": "76ff8fdf09ece9bbfd7918df462ffacad9ef71df",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1741842488,
-        "narHash": "sha256-bqqnkoXND8Sfc2MnTIKBRQSYed0fjgMn481wiIhwyz4=",
+        "lastModified": 1742013576,
+        "narHash": "sha256-wgzv3IFBxJkAYfLG0vCp1jbajHKrrpFzKZ2BssWVSlo=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c95015d7066476d32784c6f0ed7463b92b931bec",
+        "rev": "466490c252d06f42a9c165f361de74a6e6abad8d",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741914680,
-        "narHash": "sha256-Vu4DIZvgfWMzhUyxbHUrJaQb5232S5vuwxQ2sBcBVHk=",
+        "lastModified": 1741955947,
+        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30cce6848a5aa41ceb5fb33185b84868cc3e9bef",
+        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741906019,
-        "narHash": "sha256-c9L0yCdpBzPVTcExcqTti6vP6GuPVaCaVCDf0M8eu+I=",
+        "lastModified": 1742013980,
+        "narHash": "sha256-34YbfwABU5nb0F5eaaJE3ujldaNDhmyxw7CWqhXJV08=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4d8a451649b6de429ea7e169378488305d0d9399",
+        "rev": "9175b4bb5f127fb7b5784b14f7e01abff24c378f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Mar 15 05:13:41 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/76ff8fdf09ece9bbfd7918df462ffacad9ef71df' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/466490c252d06f42a9c165f361de74a6e6abad8d' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4' into the Git cache...
unpacking 'github:LnL7/nix-darwin/9175b4bb5f127fb7b5784b14f7e01abff24c378f' into the Git cache...
unpacking 'github:nix-community/nix-index-database/66537fb185462ba9b07f4e6f2d54894a1b2d04ab' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/5d76001e33ee19644a598ad80e7318ab0957b122' into the Git cache...
unpacking 'github:nixos/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f' into the Git cache...
unpacking 'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/658dfdb19eab4766270ffd20f36c55dc7dc8ed30?narHash=sha256-%2B4vOgmO/RLRW7VQyL%2Bua5Q/sKZbp3Cg9IumqWlOcuK4%3D' (2025-03-11)
  → 'github:numtide/blueprint/76ff8fdf09ece9bbfd7918df462ffacad9ef71df?narHash=sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos%3D' (2025-03-14)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/c95015d7066476d32784c6f0ed7463b92b931bec?narHash=sha256-bqqnkoXND8Sfc2MnTIKBRQSYed0fjgMn481wiIhwyz4%3D' (2025-03-13)
  → 'github:doomemacs/doomemacs/466490c252d06f42a9c165f361de74a6e6abad8d?narHash=sha256-wgzv3IFBxJkAYfLG0vCp1jbajHKrrpFzKZ2BssWVSlo%3D' (2025-03-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/30cce6848a5aa41ceb5fb33185b84868cc3e9bef?narHash=sha256-Vu4DIZvgfWMzhUyxbHUrJaQb5232S5vuwxQ2sBcBVHk%3D' (2025-03-14)
  → 'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4?narHash=sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY%3D' (2025-03-14)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/4d8a451649b6de429ea7e169378488305d0d9399?narHash=sha256-c9L0yCdpBzPVTcExcqTti6vP6GuPVaCaVCDf0M8eu%2BI%3D' (2025-03-13)
  → 'github:LnL7/nix-darwin/9175b4bb5f127fb7b5784b14f7e01abff24c378f?narHash=sha256-34YbfwABU5nb0F5eaaJE3ujldaNDhmyxw7CWqhXJV08%3D' (2025-03-15)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
