### PR TITLE
Updating flake inputs Sun Mar 16 05:13:35 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741619381,
-        "narHash": "sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE=",
+        "lastModified": 1742096597,
+        "narHash": "sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "66537fb185462ba9b07f4e6f2d54894a1b2d04ab",
+        "rev": "5c77c6d6f2e8cc6007c2b1a4df1a507834404a67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sun Mar 16 05:13:35 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/466490c252d06f42a9c165f361de74a6e6abad8d' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4' into the Git cache...
unpacking 'github:LnL7/nix-darwin/9175b4bb5f127fb7b5784b14f7e01abff24c378f' into the Git cache...
unpacking 'github:nix-community/nix-index-database/5c77c6d6f2e8cc6007c2b1a4df1a507834404a67' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/5d76001e33ee19644a598ad80e7318ab0957b122' into the Git cache...
unpacking 'github:nixos/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f' into the Git cache...
unpacking 'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/66537fb185462ba9b07f4e6f2d54894a1b2d04ab?narHash=sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE%3D' (2025-03-10)
  → 'github:nix-community/nix-index-database/5c77c6d6f2e8cc6007c2b1a4df1a507834404a67?narHash=sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU%3D' (2025-03-16)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
