### PR TITLE
Updating flake inputs Wed Mar 19 05:14:48 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742376042,
-        "narHash": "sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos=",
+        "lastModified": 1742457865,
+        "narHash": "sha256-pSs0DuhXhXgjpIj+R+KitAcFYbHTiHmMqdYYhVPI4+Q=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "33e0f1c491e9f4c446e142f8b9edd23be43d188a",
+        "rev": "7ae8756a68c662d551e354beb537f365b80e5108",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742442527,
-        "narHash": "sha256-P3hEYEIryixLQWeKOYjyxv6bIQIDoyNAuvEq+tfJc6k=",
+        "lastModified": 1742569620,
+        "narHash": "sha256-igC2cu+cPRB3E4QwKR+vGagyAtoyB+DrmWwDKm8jkaw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "97a00e0659b2807454507eb3a593bd09b099bd80",
+        "rev": "8a68f18e96bcab13e4f97bece61e6602298a3141",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742209789,
-        "narHash": "sha256-D3GWoPC7dbF4LSJ5VfskuD6K77Ej4WyTsynJ06eh9kw=",
+        "lastModified": 1742481215,
+        "narHash": "sha256-m7I/2UaGEFOI+Cy0RoADBi10NZt1WD5N3q2jUwPprE4=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "bc827c2924c46f2344d3168fd82c6711aaceb610",
+        "rev": "96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742272065,
-        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
+        "lastModified": 1742456341,
+        "narHash": "sha256-yvdnTnROddjHxoQqrakUQWDZSzVchczfsuuMOxg476c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
+        "rev": "7344a3b78128f7b1765dba89060b015fb75431a7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,5 @@
     inputs:
     inputs.blueprint {
       inherit inputs;
-      nixpkgs.config.allowUnfree = true;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -67,5 +67,8 @@
     doom-emacs.flake = false;
   };
 
-  outputs = inputs: inputs.blueprint { inherit inputs; };
+  outputs = inputs: inputs.blueprint {
+    inherit inputs;
+    nixpkgs.config.allowUnfree = true;
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -67,8 +67,10 @@
     doom-emacs.flake = false;
   };
 
-  outputs = inputs: inputs.blueprint {
-    inherit inputs;
-    nixpkgs.config.allowUnfree = true;
-  };
+  outputs =
+    inputs:
+    inputs.blueprint {
+      inherit inputs;
+      nixpkgs.config.allowUnfree = true;
+    };
 }

--- a/modules/home/vic-desktop.nix
+++ b/modules/home/vic-desktop.nix
@@ -6,6 +6,8 @@
     vscode
     wezterm
     ghostty
+    code-cursor
+    zed-editor
   ];
 
 }

--- a/modules/home/vic.nix
+++ b/modules/home/vic.nix
@@ -38,6 +38,8 @@
       tig # alucard
       cachix
       gh
+      jq
+      nix-search-cli
     ])
     ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [
       pkgs.wl-clipboard

--- a/modules/home/vic/dots.nix
+++ b/modules/home/vic/dots.nix
@@ -17,6 +17,7 @@ in
 
   home.file.".config/nvim".source = dotsLink "config/nvim";
   home.file.".config/doom".source = dotsLink "config/doom";
+  home.file.".config/zed".source = dotsLink "config/zed";
   home.file.".config/wezterm".source = dotsLink "config/wezterm";
   home.file.".config/ghostty".source = dotsLink "config/ghostty";
 

--- a/modules/home/vic/dots/config/ghostty/flake.lock
+++ b/modules/home/vic/dots/config/ghostty/flake.lock
@@ -1,0 +1,446 @@
+{
+  "nodes": {
+    "SPC": {
+      "inputs": {
+        "bats-assert": "bats-assert",
+        "bats-support": "bats-support",
+        "blueprint": [
+          "blueprint"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741482962,
+        "narHash": "sha256-vCQrmxLw+xgytWR7+cyGdYYV22Jb8iTC9/pbtyJSOX0=",
+        "owner": "vic",
+        "repo": "SPC",
+        "rev": "c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "SPC",
+        "type": "github"
+      }
+    },
+    "bats-assert": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741000361,
+        "narHash": "sha256-9EApYZwmurz7HgTQmkSGts2is/vj9BYFvEGbRYw8WJQ=",
+        "owner": "bats-core",
+        "repo": "bats-assert",
+        "rev": "0ec504eb523fd87af924ad77e1221ee4fb8c1596",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bats-core",
+        "repo": "bats-assert",
+        "type": "github"
+      }
+    },
+    "bats-support": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1481062092,
+        "narHash": "sha256-5sVpojS4mHREfSgOblWCdQ+VKMWhnO0P62gzORSVpos=",
+        "owner": "ztombol",
+        "repo": "bats-support",
+        "rev": "004e707638eedd62e0481e8cdc9223ad471f12ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ztombol",
+        "repo": "bats-support",
+        "type": "github"
+      }
+    },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742376042,
+        "narHash": "sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "33e0f1c491e9f4c446e142f8b9edd23be43d188a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "cli-leader": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1535730734,
+        "narHash": "sha256-t20pzwGUZnMmwmYqAw4im45q7/bdKBTsFTvj30o4Kr8=",
+        "owner": "dhamidi",
+        "repo": "leader",
+        "rev": "14373a25d8693681e7917f230de555977a12d2ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dhamidi",
+        "ref": "14373a2",
+        "repo": "leader",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "main",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "doom-emacs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1742013576,
+        "narHash": "sha256-wgzv3IFBxJkAYfLG0vCp1jbajHKrrpFzKZ2BssWVSlo=",
+        "owner": "doomemacs",
+        "repo": "doomemacs",
+        "rev": "466490c252d06f42a9c165f361de74a6e6abad8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "doomemacs",
+        "repo": "doomemacs",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742442527,
+        "narHash": "sha256-P3hEYEIryixLQWeKOYjyxv6bIQIDoyNAuvEq+tfJc6k=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "97a00e0659b2807454507eb3a593bd09b099bd80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742373336,
+        "narHash": "sha256-oEF5dBlq8wGD3mkJ5PmFS1PGb28uYmvuy1IH6roIGkQ=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "2d9b63316926aa130a5a51136d93b9be28808f26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742174123,
+        "narHash": "sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "main",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742209789,
+        "narHash": "sha256-D3GWoPC7dbF4LSJ5VfskuD6K77Ej4WyTsynJ06eh9kw=",
+        "owner": "nix-community",
+        "repo": "nixos-wsl",
+        "rev": "bc827c2924c46f2344d3168fd82c6711aaceb610",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "main",
+        "repo": "nixos-wsl",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742272065,
+        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nox": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741914482,
+        "narHash": "sha256-bDrZUOuzPaNhvyeLwKq/FeauAT2HXeZquaM3Qm4wbuw=",
+        "owner": "madsbv",
+        "repo": "nix-options-search",
+        "rev": "fad08278c264f5bfd26141522b8910413c77fd7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "madsbv",
+        "ref": "main",
+        "repo": "nix-options-search",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "SPC": "SPC",
+        "blueprint": "blueprint",
+        "cli-leader": "cli-leader",
+        "devshell": "devshell",
+        "doom-emacs": "doom-emacs",
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nix-index-database": "nix-index-database",
+        "nixos-wsl": "nixos-wsl",
+        "nixpkgs": "nixpkgs",
+        "nox": "nox",
+        "sops-nix": "sops-nix",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix",
+        "use_devshell_toml": "use_devshell_toml",
+        "vscode-server": "vscode-server"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742406979,
+        "narHash": "sha256-r0aq70/3bmfjTP+JZs4+XV5SgmCtk1BLU4CQPWGtA7o=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "1770be8ad89e41f1ed5a60ce628dd10877cb3609",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "ref": "master",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "ref": "main",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742370146,
+        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "use_devshell_toml": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741354009,
+        "narHash": "sha256-+zXgbNiN9Cwnd/21vY7Wo31/gkyKUbaoXHIx65KY79o=",
+        "owner": "vic",
+        "repo": "use_devshell_toml",
+        "rev": "63f65adffe7d94a237552451bd70b10372492dab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "use_devshell_toml",
+        "type": "github"
+      }
+    },
+    "vscode-server": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729422940,
+        "narHash": "sha256-DlvJv33ml5UTKgu4b0HauOfFIoDx6QXtbqUF3vWeRCY=",
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
+        "rev": "8b6db451de46ecf9b4ab3d01ef76e59957ff549f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "nixos-vscode-server",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/modules/home/vic/dots/config/zed/keymap.json
+++ b/modules/home/vic/dots/config/zed/keymap.json
@@ -1,0 +1,21 @@
+// Zed keymap
+//
+// For information on binding keys, see the Zed
+// documentation: https://zed.dev/docs/key-bindings
+//
+// To see the default key bindings run `zed: open default keymap`
+// from the command palette.
+[
+  {
+    "context": "Workspace",
+    "bindings": {
+      // "shift shift": "file_finder::Toggle"
+    }
+  },
+  {
+    "context": "Editor",
+    "bindings": {
+      // "j k": ["workspace::SendKeystrokes", "escape"]
+    }
+  }
+]

--- a/modules/home/vic/dots/config/zed/settings.json
+++ b/modules/home/vic/dots/config/zed/settings.json
@@ -1,0 +1,20 @@
+// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+//
+// To see all of Zed's default settings without changing your
+// custom settings, run `zed: open default settings` from the
+// command palette (cmd-shift-p / ctrl-shift-p)
+{
+  "current_line_highlight": "gutter",
+  "load_direnv": "direct",
+  "vim_mode": true,
+  "ui_font_size": 16,
+  "buffer_font_size": 16,
+  "theme": {
+    "mode": "system",
+    "light": "One Light",
+    "dark": "Base16 Rebecca"
+  }
+}

--- a/modules/nixos/nix-features.nix
+++ b/modules/nixos/nix-features.nix
@@ -1,5 +1,6 @@
 { config, pkgs, ... }:
 {
+  nixpkgs.config.allowUnfree = true;
   nix = {
     settings = {
       auto-optimise-store = true;

--- a/modules/nixos/nix-features.nix
+++ b/modules/nixos/nix-features.nix
@@ -1,7 +1,5 @@
 { config, pkgs, ... }:
 {
-  nixpkgs.config.allowUnfree = true;
-
   nix = {
     settings = {
       auto-optimise-store = true;


### PR DESCRIPTION
Updating flake inputs Wed Mar 19 05:14:48 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/a18c84c0f727485887fa8082a8c2b06767cc53ae' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/466490c252d06f42a9c165f361de74a6e6abad8d' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/22a36aa709de7dd42b562a433b9cefecf104a6ee' into the Git cache...
unpacking 'github:LnL7/nix-darwin/95eac71bf52b271523d0ca81dbbeb3182990fc24' into the Git cache...
unpacking 'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/bc827c2924c46f2344d3168fd82c6711aaceb610' into the Git cache...
unpacking 'github:nixos/nixpkgs/9bc8a90931262245919a26f995c1f24c6c70d3fe' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/787afce414bcce803b605c510b60bf43c11f4b55' into the Git cache...
unpacking 'github:numtide/treefmt-nix/b3b938ab8ba2e8a0ce9ee9b30ccfa5e903ae5753' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/76ff8fdf09ece9bbfd7918df462ffacad9ef71df?narHash=sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos%3D' (2025-03-14)
  → 'github:numtide/blueprint/a18c84c0f727485887fa8082a8c2b06767cc53ae?narHash=sha256-NVPM3j8VUWRUynuvjyIyc5G3vUHwKm%2BmiwUkV2Z8E6s%3D' (2025-03-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4?narHash=sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY%3D' (2025-03-14)
  → 'github:nix-community/home-manager/22a36aa709de7dd42b562a433b9cefecf104a6ee?narHash=sha256-Tumt3tcMXJniSh7tw2gW%2BWAnVLeB3WWm%2BE%2ByYFnLBXo%3D' (2025-03-18)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/9175b4bb5f127fb7b5784b14f7e01abff24c378f?narHash=sha256-34YbfwABU5nb0F5eaaJE3ujldaNDhmyxw7CWqhXJV08%3D' (2025-03-15)
  → 'github:LnL7/nix-darwin/95eac71bf52b271523d0ca81dbbeb3182990fc24?narHash=sha256-WKzuVsHXjuxYjS9KxKdpoPWpT37LofyS5llSssEw058%3D' (2025-03-16)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/5c77c6d6f2e8cc6007c2b1a4df1a507834404a67?narHash=sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU%3D' (2025-03-16)
  → 'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c?narHash=sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y%3D' (2025-03-17)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/5d76001e33ee19644a598ad80e7318ab0957b122?narHash=sha256-odXRdNZGdXg1LmwlAeWL85kgy/FVHsgKlDwrvbR2BsU%3D' (2025-03-13)
  → 'github:nix-community/nixos-wsl/bc827c2924c46f2344d3168fd82c6711aaceb610?narHash=sha256-D3GWoPC7dbF4LSJ5VfskuD6K77Ej4WyTsynJ06eh9kw%3D' (2025-03-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a?narHash=sha256-4thdbnP6dlbdq%2BqZWTsm4ffAwoS8Tiq1YResB%2BRP6WE%3D' (2025-03-13)
  → 'github:nixos/nixpkgs/9bc8a90931262245919a26f995c1f24c6c70d3fe?narHash=sha256-xlpHmgBxUnvHo8FNnju0sgnEyasb4gC607b%2BkeqjmX8%3D' (2025-03-17)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f?narHash=sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0%3D' (2025-03-13)
  → 'github:Mic92/sops-nix/787afce414bcce803b605c510b60bf43c11f4b55?narHash=sha256-ptn8dR4Uat3UUadGYNnB7CIH9SQm8mK69D2A/twBUXQ%3D' (2025-03-17)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204?narHash=sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU%3D' (2025-02-17)
  → 'github:numtide/treefmt-nix/b3b938ab8ba2e8a0ce9ee9b30ccfa5e903ae5753?narHash=sha256-2R7cGdcA2npQQcIWu2cTlU63veTzwVZe78BliIuJT00%3D' (2025-03-18)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
