### PR TITLE
Updating flake inputs Thu Mar 20 05:14:51 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741947577,
+        "lastModified": 1742376042,
         "narHash": "sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "76ff8fdf09ece9bbfd7918df462ffacad9ef71df",
+        "rev": "33e0f1c491e9f4c446e142f8b9edd23be43d188a",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741955947,
-        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
+        "lastModified": 1742442527,
+        "narHash": "sha256-P3hEYEIryixLQWeKOYjyxv6bIQIDoyNAuvEq+tfJc6k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
+        "rev": "97a00e0659b2807454507eb3a593bd09b099bd80",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742013980,
-        "narHash": "sha256-34YbfwABU5nb0F5eaaJE3ujldaNDhmyxw7CWqhXJV08=",
+        "lastModified": 1742373336,
+        "narHash": "sha256-oEF5dBlq8wGD3mkJ5PmFS1PGb28uYmvuy1IH6roIGkQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "9175b4bb5f127fb7b5784b14f7e01abff24c378f",
+        "rev": "2d9b63316926aa130a5a51136d93b9be28808f26",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742096597,
-        "narHash": "sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU=",
+        "lastModified": 1742174123,
+        "narHash": "sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "5c77c6d6f2e8cc6007c2b1a4df1a507834404a67",
+        "rev": "2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741870048,
-        "narHash": "sha256-odXRdNZGdXg1LmwlAeWL85kgy/FVHsgKlDwrvbR2BsU=",
+        "lastModified": 1742209789,
+        "narHash": "sha256-D3GWoPC7dbF4LSJ5VfskuD6K77Ej4WyTsynJ06eh9kw=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "5d76001e33ee19644a598ad80e7318ab0957b122",
+        "rev": "bc827c2924c46f2344d3168fd82c6711aaceb610",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741865919,
-        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
+        "lastModified": 1742272065,
+        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
         "type": "github"
       },
       "original": {
@@ -343,11 +343,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741861888,
-        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
+        "lastModified": 1742406979,
+        "narHash": "sha256-r0aq70/3bmfjTP+JZs4+XV5SgmCtk1BLU4CQPWGtA7o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
+        "rev": "1770be8ad89e41f1ed5a60ce628dd10877cb3609",
         "type": "github"
       },
       "original": {
@@ -380,11 +380,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1742370146,
+        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Mar 20 05:14:51 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/33e0f1c491e9f4c446e142f8b9edd23be43d188a' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/466490c252d06f42a9c165f361de74a6e6abad8d' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/97a00e0659b2807454507eb3a593bd09b099bd80' into the Git cache...
unpacking 'github:LnL7/nix-darwin/2d9b63316926aa130a5a51136d93b9be28808f26' into the Git cache...
unpacking 'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/bc827c2924c46f2344d3168fd82c6711aaceb610' into the Git cache...
unpacking 'github:nixos/nixpkgs/3549532663732bfd89993204d40543e9edaec4f2' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/1770be8ad89e41f1ed5a60ce628dd10877cb3609' into the Git cache...
unpacking 'github:numtide/treefmt-nix/adc195eef5da3606891cedf80c0d9ce2d3190808' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/76ff8fdf09ece9bbfd7918df462ffacad9ef71df?narHash=sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos%3D' (2025-03-14)
  → 'github:numtide/blueprint/33e0f1c491e9f4c446e142f8b9edd23be43d188a?narHash=sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos%3D' (2025-03-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4?narHash=sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY%3D' (2025-03-14)
  → 'github:nix-community/home-manager/97a00e0659b2807454507eb3a593bd09b099bd80?narHash=sha256-P3hEYEIryixLQWeKOYjyxv6bIQIDoyNAuvEq%2BtfJc6k%3D' (2025-03-20)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/9175b4bb5f127fb7b5784b14f7e01abff24c378f?narHash=sha256-34YbfwABU5nb0F5eaaJE3ujldaNDhmyxw7CWqhXJV08%3D' (2025-03-15)
  → 'github:LnL7/nix-darwin/2d9b63316926aa130a5a51136d93b9be28808f26?narHash=sha256-oEF5dBlq8wGD3mkJ5PmFS1PGb28uYmvuy1IH6roIGkQ%3D' (2025-03-19)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/5c77c6d6f2e8cc6007c2b1a4df1a507834404a67?narHash=sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU%3D' (2025-03-16)
  → 'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c?narHash=sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y%3D' (2025-03-17)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/5d76001e33ee19644a598ad80e7318ab0957b122?narHash=sha256-odXRdNZGdXg1LmwlAeWL85kgy/FVHsgKlDwrvbR2BsU%3D' (2025-03-13)
  → 'github:nix-community/nixos-wsl/bc827c2924c46f2344d3168fd82c6711aaceb610?narHash=sha256-D3GWoPC7dbF4LSJ5VfskuD6K77Ej4WyTsynJ06eh9kw%3D' (2025-03-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a?narHash=sha256-4thdbnP6dlbdq%2BqZWTsm4ffAwoS8Tiq1YResB%2BRP6WE%3D' (2025-03-13)
  → 'github:nixos/nixpkgs/3549532663732bfd89993204d40543e9edaec4f2?narHash=sha256-ud8vcSzJsZ/CK%2Br8/v0lyf4yUntVmDq6Z0A41ODfWbE%3D' (2025-03-18)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f?narHash=sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0%3D' (2025-03-13)
  → 'github:Mic92/sops-nix/1770be8ad89e41f1ed5a60ce628dd10877cb3609?narHash=sha256-r0aq70/3bmfjTP%2BJZs4%2BXV5SgmCtk1BLU4CQPWGtA7o%3D' (2025-03-19)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204?narHash=sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU%3D' (2025-02-17)
  → 'github:numtide/treefmt-nix/adc195eef5da3606891cedf80c0d9ce2d3190808?narHash=sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU%3D' (2025-03-19)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
