### PR TITLE
Updating flake inputs Fri Mar 21 05:14:39 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742376042,
-        "narHash": "sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos=",
+        "lastModified": 1742457865,
+        "narHash": "sha256-pSs0DuhXhXgjpIj+R+KitAcFYbHTiHmMqdYYhVPI4+Q=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "33e0f1c491e9f4c446e142f8b9edd23be43d188a",
+        "rev": "7ae8756a68c662d551e354beb537f365b80e5108",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742442527,
-        "narHash": "sha256-P3hEYEIryixLQWeKOYjyxv6bIQIDoyNAuvEq+tfJc6k=",
+        "lastModified": 1742530487,
+        "narHash": "sha256-yjBjRn294NpPagPAQCio20X5BzBXiOoz2+xF3/YmEkU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "97a00e0659b2807454507eb3a593bd09b099bd80",
+        "rev": "d61711497be9ad6a6633aaf203b038b5a970621f",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742209789,
-        "narHash": "sha256-D3GWoPC7dbF4LSJ5VfskuD6K77Ej4WyTsynJ06eh9kw=",
+        "lastModified": 1742481215,
+        "narHash": "sha256-m7I/2UaGEFOI+Cy0RoADBi10NZt1WD5N3q2jUwPprE4=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "bc827c2924c46f2344d3168fd82c6711aaceb610",
+        "rev": "96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742272065,
-        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
+        "lastModified": 1742395137,
+        "narHash": "sha256-WWNNjCSzQCtATpCFEijm81NNG1xqlLMVbIzXAiZysbs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
+        "rev": "2a725d40de138714db4872dc7405d86457aa17ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Mar 21 05:14:39 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/7ae8756a68c662d551e354beb537f365b80e5108' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/466490c252d06f42a9c165f361de74a6e6abad8d' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/d61711497be9ad6a6633aaf203b038b5a970621f' into the Git cache...
unpacking 'github:LnL7/nix-darwin/2d9b63316926aa130a5a51136d93b9be28808f26' into the Git cache...
unpacking 'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7' into the Git cache...
unpacking 'github:nixos/nixpkgs/2a725d40de138714db4872dc7405d86457aa17ad' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/1770be8ad89e41f1ed5a60ce628dd10877cb3609' into the Git cache...
unpacking 'github:numtide/treefmt-nix/adc195eef5da3606891cedf80c0d9ce2d3190808' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/33e0f1c491e9f4c446e142f8b9edd23be43d188a?narHash=sha256-sh09UPmrumfAEMeo50JLhGEkN/4FmEA6ad2KV5HXcos%3D' (2025-03-19)
  → 'github:numtide/blueprint/7ae8756a68c662d551e354beb537f365b80e5108?narHash=sha256-pSs0DuhXhXgjpIj%2BR%2BKitAcFYbHTiHmMqdYYhVPI4%2BQ%3D' (2025-03-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/97a00e0659b2807454507eb3a593bd09b099bd80?narHash=sha256-P3hEYEIryixLQWeKOYjyxv6bIQIDoyNAuvEq%2BtfJc6k%3D' (2025-03-20)
  → 'github:nix-community/home-manager/d61711497be9ad6a6633aaf203b038b5a970621f?narHash=sha256-yjBjRn294NpPagPAQCio20X5BzBXiOoz2%2BxF3/YmEkU%3D' (2025-03-21)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/bc827c2924c46f2344d3168fd82c6711aaceb610?narHash=sha256-D3GWoPC7dbF4LSJ5VfskuD6K77Ej4WyTsynJ06eh9kw%3D' (2025-03-17)
  → 'github:nix-community/nixos-wsl/96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7?narHash=sha256-m7I/2UaGEFOI%2BCy0RoADBi10NZt1WD5N3q2jUwPprE4%3D' (2025-03-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3549532663732bfd89993204d40543e9edaec4f2?narHash=sha256-ud8vcSzJsZ/CK%2Br8/v0lyf4yUntVmDq6Z0A41ODfWbE%3D' (2025-03-18)
  → 'github:nixos/nixpkgs/2a725d40de138714db4872dc7405d86457aa17ad?narHash=sha256-WWNNjCSzQCtATpCFEijm81NNG1xqlLMVbIzXAiZysbs%3D' (2025-03-19)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
