### PR TITLE
Updating flake inputs Sat Mar 22 05:13:51 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742546557,
-        "narHash": "sha256-QyhimDBaDBtMfRc7kyL28vo+HTwXRPq3hz+BgSJDotw=",
+        "lastModified": 1742578646,
+        "narHash": "sha256-GiQ40ndXRnmmbDZvuv762vS+gew1uDpFwOfgJ8tLiEs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfa9810ff7104a17555ab68ebdeafb6705f129b1",
+        "rev": "94c4dbe77c0740ebba36c173672ca15a7926c993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Mar 22 05:13:51 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/d92920405ac6d8364baeff3ad26b4d5db3687f50' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/296ddc64627f4a6a4eb447852d7346b9dd16197d' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e9f41de2a81f04390afd106959adf352a207628f' into the Git cache...
unpacking 'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7' into the Git cache...
unpacking 'github:nixos/nixpkgs/94c4dbe77c0740ebba36c173672ca15a7926c993' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/b7756921b002de60fb66782effad3ce8bdb5b25d' into the Git cache...
unpacking 'github:numtide/treefmt-nix/adc195eef5da3606891cedf80c0d9ce2d3190808' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bfa9810ff7104a17555ab68ebdeafb6705f129b1?narHash=sha256-QyhimDBaDBtMfRc7kyL28vo%2BHTwXRPq3hz%2BBgSJDotw%3D' (2025-03-21)
  → 'github:nixos/nixpkgs/94c4dbe77c0740ebba36c173672ca15a7926c993?narHash=sha256-GiQ40ndXRnmmbDZvuv762vS%2Bgew1uDpFwOfgJ8tLiEs%3D' (2025-03-21)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
