### PR TITLE
Updating flake inputs Tue Mar 25 05:16:14 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742457865,
-        "narHash": "sha256-pSs0DuhXhXgjpIj+R+KitAcFYbHTiHmMqdYYhVPI4+Q=",
+        "lastModified": 1742810182,
+        "narHash": "sha256-K0VpsMJHQcIfOXoYW/IDa5HNhLp02XEfUt5fCjmRQBA=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "7ae8756a68c662d551e354beb537f365b80e5108",
+        "rev": "5663edeaef8952926ce96d34a3c40d240717efcf",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1742610592,
-        "narHash": "sha256-U6fqGYmt4A2Mq3yHxdRnDqyFWOayihjvFslvWIGaQsU=",
+        "lastModified": 1742854893,
+        "narHash": "sha256-JfWx/nH6GSQa8gvMQpzMd0w//1xq7DaEWDO+feMXoxU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "d92920405ac6d8364baeff3ad26b4d5db3687f50",
+        "rev": "bdd3701987e80f1b1044d2ee0a725b5cb5828705",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742588233,
-        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
+        "lastModified": 1742871411,
+        "narHash": "sha256-F3xBdOs5m0SE6Gq3jz+JxDOPvsLs22vbGfD05uF6xEc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
+        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742595055,
-        "narHash": "sha256-cEetDber6LF8W4ThmRc4rwKs/o8y2GH0pUdX7e6CnAQ=",
+        "lastModified": 1742869675,
+        "narHash": "sha256-rgwUZJZVztaNYPTsf6MIqirPL5r2JTMMyHuzk1ezyYk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e9f41de2a81f04390afd106959adf352a207628f",
+        "rev": "bb81755a3674951724d79b8cba6bbff01409d44d",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742174123,
-        "narHash": "sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y=",
+        "lastModified": 1742701275,
+        "narHash": "sha256-AulwPVrS9859t+eJ61v24wH/nfBEIDSXYxlRo3fL/SA=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c",
+        "rev": "36dc43cb50d5d20f90a28d53abb33a32b0a2aae6",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742546557,
-        "narHash": "sha256-QyhimDBaDBtMfRc7kyL28vo+HTwXRPq3hz+BgSJDotw=",
+        "lastModified": 1742800061,
+        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfa9810ff7104a17555ab68ebdeafb6705f129b1",
+        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
         "type": "github"
       },
       "original": {
@@ -343,11 +343,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742595978,
-        "narHash": "sha256-05onsoMrLyXE4XleDCeLC3bXnC4nyUbKWInGwM7v6hU=",
+        "lastModified": 1742700801,
+        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b7756921b002de60fb66782effad3ce8bdb5b25d",
+        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Tue Mar 25 05:16:14 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/5663edeaef8952926ce96d34a3c40d240717efcf' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:doomemacs/doomemacs/bdd3701987e80f1b1044d2ee0a725b5cb5828705' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/869f2ec2add75ce2a70a6dbbf585b8399abec625' into the Git cache...
unpacking 'github:LnL7/nix-darwin/bb81755a3674951724d79b8cba6bbff01409d44d' into the Git cache...
unpacking 'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7' into the Git cache...
unpacking 'github:nixos/nixpkgs/1750f3c1c89488e2ffdd47cab9d05454dddfb734' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:Mic92/sops-nix/67566fe68a8bed2a7b1175fdfb0697ed22ae8852' into the Git cache...
unpacking 'github:numtide/treefmt-nix/adc195eef5da3606891cedf80c0d9ce2d3190808' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/7ae8756a68c662d551e354beb537f365b80e5108?narHash=sha256-pSs0DuhXhXgjpIj%2BR%2BKitAcFYbHTiHmMqdYYhVPI4%2BQ%3D' (2025-03-20)
  → 'github:numtide/blueprint/5663edeaef8952926ce96d34a3c40d240717efcf?narHash=sha256-K0VpsMJHQcIfOXoYW/IDa5HNhLp02XEfUt5fCjmRQBA%3D' (2025-03-24)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/d92920405ac6d8364baeff3ad26b4d5db3687f50?narHash=sha256-U6fqGYmt4A2Mq3yHxdRnDqyFWOayihjvFslvWIGaQsU%3D' (2025-03-22)
  → 'github:doomemacs/doomemacs/bdd3701987e80f1b1044d2ee0a725b5cb5828705?narHash=sha256-JfWx/nH6GSQa8gvMQpzMd0w//1xq7DaEWDO%2BfeMXoxU%3D' (2025-03-24)
• Updated input 'home-manager':
    'github:nix-community/home-manager/296ddc64627f4a6a4eb447852d7346b9dd16197d?narHash=sha256-Fi5g8H5FXMSRqy%2BmU6gPG0v%2BC9pzjYbkkiePtz8%2BPpA%3D' (2025-03-21)
  → 'github:nix-community/home-manager/869f2ec2add75ce2a70a6dbbf585b8399abec625?narHash=sha256-F3xBdOs5m0SE6Gq3jz%2BJxDOPvsLs22vbGfD05uF6xEc%3D' (2025-03-25)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/e9f41de2a81f04390afd106959adf352a207628f?narHash=sha256-cEetDber6LF8W4ThmRc4rwKs/o8y2GH0pUdX7e6CnAQ%3D' (2025-03-21)
  → 'github:LnL7/nix-darwin/bb81755a3674951724d79b8cba6bbff01409d44d?narHash=sha256-rgwUZJZVztaNYPTsf6MIqirPL5r2JTMMyHuzk1ezyYk%3D' (2025-03-25)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c?narHash=sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y%3D' (2025-03-17)
  → 'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6?narHash=sha256-AulwPVrS9859t%2BeJ61v24wH/nfBEIDSXYxlRo3fL/SA%3D' (2025-03-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bfa9810ff7104a17555ab68ebdeafb6705f129b1?narHash=sha256-QyhimDBaDBtMfRc7kyL28vo%2BHTwXRPq3hz%2BBgSJDotw%3D' (2025-03-21)
  → 'github:nixos/nixpkgs/1750f3c1c89488e2ffdd47cab9d05454dddfb734?narHash=sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs%3D' (2025-03-24)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/b7756921b002de60fb66782effad3ce8bdb5b25d?narHash=sha256-05onsoMrLyXE4XleDCeLC3bXnC4nyUbKWInGwM7v6hU%3D' (2025-03-21)
  → 'github:Mic92/sops-nix/67566fe68a8bed2a7b1175fdfb0697ed22ae8852?narHash=sha256-ZGlpUDsuBdeZeTNgoMv%2Baw0ByXT2J3wkYw9kJwkAS4M%3D' (2025-03-23)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
