### PR TITLE
Updating flake inputs Thu Mar 27 05:15:03 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742810182,
-        "narHash": "sha256-K0VpsMJHQcIfOXoYW/IDa5HNhLp02XEfUt5fCjmRQBA=",
+        "lastModified": 1743008896,
+        "narHash": "sha256-mU0WYwrgN8Sus4ktBsSzkvs0++vAKrhNE0A0vWo8AzY=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "5663edeaef8952926ce96d34a3c40d240717efcf",
+        "rev": "7ae2142c8b5a47bed6d403fdd5f5a1215961e10c",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1742940695,
-        "narHash": "sha256-DVgwI3K746Al9pA9s3zZ9qBcu+mcGG76EKl8bJ+mHy4=",
+        "lastModified": 1742990136,
+        "narHash": "sha256-CXl7E+X6U02HO9zUTGie6Ewhnm1ONSKQWqYfPikRI9g=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "1e1fd5c8e45382034f53d2a617697b2ba75bcc42",
+        "rev": "1ac579e08ac6e8b0f63c455eea7443ce0293b95a",
         "type": "github"
       },
       "original": {
@@ -300,11 +300,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742957044,
-        "narHash": "sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c=",
+        "lastModified": 1742996658,
+        "narHash": "sha256-snxgTLVq6ooaD3W3mPHu7LVWpoZKczhxHAUZy2ea4oA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce287a5cd3ef78203bc78021447f937a988d9f6f",
+        "rev": "693840c01b9bef9e54100239cef937e53d4661bf",
         "type": "github"
       },
       "original": {
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742481215,
-        "narHash": "sha256-m7I/2UaGEFOI+Cy0RoADBi10NZt1WD5N3q2jUwPprE4=",
+        "lastModified": 1742999260,
+        "narHash": "sha256-wgeb7kSod9MAGm39MsVLsy2zxSbtCtckCkgfbjg6TLM=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7",
+        "rev": "64d679540fa4d7e2afdbbb53ea63e3e5019c1f52",
         "type": "github"
       },
       "original": {
@@ -485,11 +485,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
+        "lastModified": 1742923925,
+        "narHash": "sha256-biPjLws6FiBVUUDHEMFq5pUQL84Wf7PntPYdo3oKkFw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "rev": "25d1b84f5c90632a623c48d83a2faf156451e6b1",
         "type": "github"
       },
       "original": {
@@ -660,11 +660,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742956365,
-        "narHash": "sha256-Slrqmt6kJ/M7Z/ce4ebQWsz2aeEodrX56CsupOEPoz0=",
+        "lastModified": 1743042789,
+        "narHash": "sha256-yPlxN0r3pQjUIwyX/qeWSTdpHjWy/AfmM0PK1bYkO18=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a0e3395c63cdbc9c1ec17915f8328c077c79c4a1",
+        "rev": "b4d2dee9d16e7725b71969f28862ded3a94a7934",
         "type": "github"
       },
       "original": {
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742370146,
-        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "lastModified": 1742982148,
+        "narHash": "sha256-aRA6LSxjlbMI6MmMzi/M5WH/ynd8pK+vACD9za3MKLQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "rev": "61c88349bf6dff49fa52d7dfc39b21026c2a8881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Mar 27 05:15:03 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/7ae2142c8b5a47bed6d403fdd5f5a1215961e10c' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/70947c1908108c0c551ddfd73d4f750ff2ea67cd' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/1ac579e08ac6e8b0f63c455eea7443ce0293b95a' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/693840c01b9bef9e54100239cef937e53d4661bf' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/63a91ec6fd2c050e0410a8f563213eeeeefcd70e' into the Git cache...
unpacking 'github:LnL7/nix-darwin/bb81755a3674951724d79b8cba6bbff01409d44d' into the Git cache...
unpacking 'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/9312e582b97053c3478b4ebd8364f4e189152d73' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/64d679540fa4d7e2afdbbb53ea63e3e5019c1f52' into the Git cache...
unpacking 'github:nixos/nixpkgs/25d1b84f5c90632a623c48d83a2faf156451e6b1' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:oxalica/rust-overlay/b4d2dee9d16e7725b71969f28862ded3a94a7934' into the Git cache...
unpacking 'github:Mic92/sops-nix/67566fe68a8bed2a7b1175fdfb0697ed22ae8852' into the Git cache...
unpacking 'github:numtide/treefmt-nix/61c88349bf6dff49fa52d7dfc39b21026c2a8881' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/5663edeaef8952926ce96d34a3c40d240717efcf?narHash=sha256-K0VpsMJHQcIfOXoYW/IDa5HNhLp02XEfUt5fCjmRQBA%3D' (2025-03-24)
  → 'github:numtide/blueprint/7ae2142c8b5a47bed6d403fdd5f5a1215961e10c?narHash=sha256-mU0WYwrgN8Sus4ktBsSzkvs0%2B%2BvAKrhNE0A0vWo8AzY%3D' (2025-03-26)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/1e1fd5c8e45382034f53d2a617697b2ba75bcc42?narHash=sha256-DVgwI3K746Al9pA9s3zZ9qBcu%2BmcGG76EKl8bJ%2BmHy4%3D' (2025-03-25)
  → 'github:doomemacs/doomemacs/1ac579e08ac6e8b0f63c455eea7443ce0293b95a?narHash=sha256-CXl7E%2BX6U02HO9zUTGie6Ewhnm1ONSKQWqYfPikRI9g%3D' (2025-03-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ce287a5cd3ef78203bc78021447f937a988d9f6f?narHash=sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c%3D' (2025-03-26)
  → 'github:nix-community/home-manager/693840c01b9bef9e54100239cef937e53d4661bf?narHash=sha256-snxgTLVq6ooaD3W3mPHu7LVWpoZKczhxHAUZy2ea4oA%3D' (2025-03-26)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7?narHash=sha256-m7I/2UaGEFOI%2BCy0RoADBi10NZt1WD5N3q2jUwPprE4%3D' (2025-03-20)
  → 'github:nix-community/nixos-wsl/64d679540fa4d7e2afdbbb53ea63e3e5019c1f52?narHash=sha256-wgeb7kSod9MAGm39MsVLsy2zxSbtCtckCkgfbjg6TLM%3D' (2025-03-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1750f3c1c89488e2ffdd47cab9d05454dddfb734?narHash=sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs%3D' (2025-03-24)
  → 'github:nixos/nixpkgs/25d1b84f5c90632a623c48d83a2faf156451e6b1?narHash=sha256-biPjLws6FiBVUUDHEMFq5pUQL84Wf7PntPYdo3oKkFw%3D' (2025-03-25)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/a0e3395c63cdbc9c1ec17915f8328c077c79c4a1?narHash=sha256-Slrqmt6kJ/M7Z/ce4ebQWsz2aeEodrX56CsupOEPoz0%3D' (2025-03-26)
  → 'github:oxalica/rust-overlay/b4d2dee9d16e7725b71969f28862ded3a94a7934?narHash=sha256-yPlxN0r3pQjUIwyX/qeWSTdpHjWy/AfmM0PK1bYkO18%3D' (2025-03-27)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/adc195eef5da3606891cedf80c0d9ce2d3190808?narHash=sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU%3D' (2025-03-19)
  → 'github:numtide/treefmt-nix/61c88349bf6dff49fa52d7dfc39b21026c2a8881?narHash=sha256-aRA6LSxjlbMI6MmMzi/M5WH/ynd8pK%2BvACD9za3MKLQ%3D' (2025-03-26)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
