### PR TITLE
Updating flake inputs Sat Mar 29 05:13:44 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742810182,
-        "narHash": "sha256-K0VpsMJHQcIfOXoYW/IDa5HNhLp02XEfUt5fCjmRQBA=",
+        "lastModified": 1743008896,
+        "narHash": "sha256-mU0WYwrgN8Sus4ktBsSzkvs0++vAKrhNE0A0vWo8AzY=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "5663edeaef8952926ce96d34a3c40d240717efcf",
+        "rev": "7ae2142c8b5a47bed6d403fdd5f5a1215961e10c",
         "type": "github"
       },
       "original": {
@@ -168,14 +168,35 @@
         "type": "github"
       }
     },
+    "devshell_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-versions",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1742940695,
-        "narHash": "sha256-DVgwI3K746Al9pA9s3zZ9qBcu+mcGG76EKl8bJ+mHy4=",
+        "lastModified": 1743147083,
+        "narHash": "sha256-KoZKa2eP438dU27YsG40Xjg8EeRPfcJ0NmF7stz2BgI=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "1e1fd5c8e45382034f53d2a617697b2ba75bcc42",
+        "rev": "9e624b5dfe54b7d8523d55313c22a5ef54659540",
         "type": "github"
       },
       "original": {
@@ -300,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742957044,
-        "narHash": "sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c=",
+        "lastModified": 1743136572,
+        "narHash": "sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce287a5cd3ef78203bc78021447f937a988d9f6f",
+        "rev": "1efd2503172016a6742c87b47b43ca2c8145607d",
         "type": "github"
       },
       "original": {
@@ -351,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742969816,
-        "narHash": "sha256-eeZE4HIWLyhA7hHU9D1xgXZdTDAm52dqnASsypIeJ5o=",
+        "lastModified": 1743142629,
+        "narHash": "sha256-SIwwnO0dbpVzyanXe4ecKe/axg2LNRc3qEpIbWo8gKo=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "63a91ec6fd2c050e0410a8f563213eeeeefcd70e",
+        "rev": "69a874c5070f9e718a9b2c125cafc0ffc4b5babf",
         "type": "github"
       },
       "original": {
@@ -371,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742869675,
-        "narHash": "sha256-rgwUZJZVztaNYPTsf6MIqirPL5r2JTMMyHuzk1ezyYk=",
+        "lastModified": 1743221873,
+        "narHash": "sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bb81755a3674951724d79b8cba6bbff01409d44d",
+        "rev": "53d0f0ed11487a4476741fde757d0feabef4cc4e",
         "type": "github"
       },
       "original": {
@@ -434,6 +455,7 @@
     },
     "nix-versions": {
       "inputs": {
+        "devshell": "devshell_2",
         "flake-parts": [
           "flake-parts"
         ],
@@ -448,11 +470,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742806119,
-        "narHash": "sha256-SA6QzbB8y/3npzaSyujLZIJsjoLxSN9Fy1ZiRXafbQ4=",
+        "lastModified": 1743194778,
+        "narHash": "sha256-3Pk3yttLli8AFZ695I/zrUX8GNb1FNTbT8CdyRRf+pE=",
         "owner": "vic",
         "repo": "nix-versions",
-        "rev": "9312e582b97053c3478b4ebd8364f4e189152d73",
+        "rev": "c5da13738d7dacfecd7ff33528857e2039795123",
         "type": "github"
       },
       "original": {
@@ -469,11 +491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742481215,
-        "narHash": "sha256-m7I/2UaGEFOI+Cy0RoADBi10NZt1WD5N3q2jUwPprE4=",
+        "lastModified": 1743125458,
+        "narHash": "sha256-0z+5AMacL2Eqo92fAd0eCWeKVecWrxPJwd5/BIfcdJ8=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7",
+        "rev": "394c77f61ac76399290bfc2ef9d47b1fba31b215",
         "type": "github"
       },
       "original": {
@@ -485,11 +507,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
+        "lastModified": 1743076231,
+        "narHash": "sha256-yQugdVfi316qUfqzN8JMaA2vixl+45GxNm4oUfXlbgw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "rev": "6c5963357f3c1c840201eda129a99d455074db04",
         "type": "github"
       },
       "original": {
@@ -660,11 +682,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742956365,
-        "narHash": "sha256-Slrqmt6kJ/M7Z/ce4ebQWsz2aeEodrX56CsupOEPoz0=",
+        "lastModified": 1743215516,
+        "narHash": "sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL+9TWv2UDCEPNI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a0e3395c63cdbc9c1ec17915f8328c077c79c4a1",
+        "rev": "524463199fdee49338006b049bc376b965a2cfed",
         "type": "github"
       },
       "original": {
@@ -740,11 +762,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742370146,
-        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Mar 29 05:13:44 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/7ae2142c8b5a47bed6d403fdd5f5a1215961e10c' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/70947c1908108c0c551ddfd73d4f750ff2ea67cd' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/9e624b5dfe54b7d8523d55313c22a5ef54659540' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/1efd2503172016a6742c87b47b43ca2c8145607d' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/69a874c5070f9e718a9b2c125cafc0ffc4b5babf' into the Git cache...
unpacking 'github:LnL7/nix-darwin/53d0f0ed11487a4476741fde757d0feabef4cc4e' into the Git cache...
unpacking 'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/c5da13738d7dacfecd7ff33528857e2039795123' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04' into the Git cache...
unpacking 'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c' into the Git cache...
unpacking 'github:oxalica/rust-overlay/524463199fdee49338006b049bc376b965a2cfed' into the Git cache...
unpacking 'github:Mic92/sops-nix/67566fe68a8bed2a7b1175fdfb0697ed22ae8852' into the Git cache...
unpacking 'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/5663edeaef8952926ce96d34a3c40d240717efcf?narHash=sha256-K0VpsMJHQcIfOXoYW/IDa5HNhLp02XEfUt5fCjmRQBA%3D' (2025-03-24)
  → 'github:numtide/blueprint/7ae2142c8b5a47bed6d403fdd5f5a1215961e10c?narHash=sha256-mU0WYwrgN8Sus4ktBsSzkvs0%2B%2BvAKrhNE0A0vWo8AzY%3D' (2025-03-26)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/1e1fd5c8e45382034f53d2a617697b2ba75bcc42?narHash=sha256-DVgwI3K746Al9pA9s3zZ9qBcu%2BmcGG76EKl8bJ%2BmHy4%3D' (2025-03-25)
  → 'github:doomemacs/doomemacs/9e624b5dfe54b7d8523d55313c22a5ef54659540?narHash=sha256-KoZKa2eP438dU27YsG40Xjg8EeRPfcJ0NmF7stz2BgI%3D' (2025-03-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ce287a5cd3ef78203bc78021447f937a988d9f6f?narHash=sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c%3D' (2025-03-26)
  → 'github:nix-community/home-manager/1efd2503172016a6742c87b47b43ca2c8145607d?narHash=sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54%3D' (2025-03-28)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/63a91ec6fd2c050e0410a8f563213eeeeefcd70e?narHash=sha256-eeZE4HIWLyhA7hHU9D1xgXZdTDAm52dqnASsypIeJ5o%3D' (2025-03-26)
  → 'github:yusdacra/nix-cargo-integration/69a874c5070f9e718a9b2c125cafc0ffc4b5babf?narHash=sha256-SIwwnO0dbpVzyanXe4ecKe/axg2LNRc3qEpIbWo8gKo%3D' (2025-03-28)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/bb81755a3674951724d79b8cba6bbff01409d44d?narHash=sha256-rgwUZJZVztaNYPTsf6MIqirPL5r2JTMMyHuzk1ezyYk%3D' (2025-03-25)
  → 'github:LnL7/nix-darwin/53d0f0ed11487a4476741fde757d0feabef4cc4e?narHash=sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs%3D' (2025-03-29)
• Updated input 'nix-versions':
    'github:vic/nix-versions/9312e582b97053c3478b4ebd8364f4e189152d73?narHash=sha256-SA6QzbB8y/3npzaSyujLZIJsjoLxSN9Fy1ZiRXafbQ4%3D' (2025-03-24)
  → 'github:vic/nix-versions/c5da13738d7dacfecd7ff33528857e2039795123?narHash=sha256-3Pk3yttLli8AFZ695I/zrUX8GNb1FNTbT8CdyRRf%2BpE%3D' (2025-03-28)
• Added input 'nix-versions/devshell':
    'github:numtide/devshell/7c9e793ebe66bcba8292989a68c0419b737a22a0?narHash=sha256-kWNaq6wQUbUMlPgw8Y%2B9/9wP0F8SHkjy24/mN3UAppg%3D' (2025-03-08)
• Added input 'nix-versions/devshell/nixpkgs':
    follows 'nix-versions/nixpkgs'
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/96d7df91cce0d7cd30d1958fe1aefcb5f9bfced7?narHash=sha256-m7I/2UaGEFOI%2BCy0RoADBi10NZt1WD5N3q2jUwPprE4%3D' (2025-03-20)
  → 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215?narHash=sha256-0z%2B5AMacL2Eqo92fAd0eCWeKVecWrxPJwd5/BIfcdJ8%3D' (2025-03-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1750f3c1c89488e2ffdd47cab9d05454dddfb734?narHash=sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs%3D' (2025-03-24)
  → 'github:nixos/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04?narHash=sha256-yQugdVfi316qUfqzN8JMaA2vixl%2B45GxNm4oUfXlbgw%3D' (2025-03-27)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/a0e3395c63cdbc9c1ec17915f8328c077c79c4a1?narHash=sha256-Slrqmt6kJ/M7Z/ce4ebQWsz2aeEodrX56CsupOEPoz0%3D' (2025-03-26)
  → 'github:oxalica/rust-overlay/524463199fdee49338006b049bc376b965a2cfed?narHash=sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL%2B9TWv2UDCEPNI%3D' (2025-03-29)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/adc195eef5da3606891cedf80c0d9ce2d3190808?narHash=sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU%3D' (2025-03-19)
  → 'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7?narHash=sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE%3D' (2025-03-27)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
