### PR TITLE
Updating flake inputs Sun Mar 30 05:13:52 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743136572,
-        "narHash": "sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54=",
+        "lastModified": 1743295846,
+        "narHash": "sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1efd2503172016a6742c87b47b43ca2c8145607d",
+        "rev": "717030011980e9eb31eb8ce011261dd532bce92c",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742701275,
-        "narHash": "sha256-AulwPVrS9859t+eJ61v24wH/nfBEIDSXYxlRo3fL/SA=",
+        "lastModified": 1743306489,
+        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "36dc43cb50d5d20f90a28d53abb33a32b0a2aae6",
+        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
         "type": "github"
       },
       "original": {
@@ -470,11 +470,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743194778,
-        "narHash": "sha256-3Pk3yttLli8AFZ695I/zrUX8GNb1FNTbT8CdyRRf+pE=",
+        "lastModified": 1743311161,
+        "narHash": "sha256-7Q3Akhh0DrpxZ5ifoV2Z+vcWT1vYhFFs2JncJneBGMQ=",
         "owner": "vic",
         "repo": "nix-versions",
-        "rev": "c5da13738d7dacfecd7ff33528857e2039795123",
+        "rev": "47f55ed32b2820259cd4c196b759086e9dd82b9e",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741914482,
-        "narHash": "sha256-bDrZUOuzPaNhvyeLwKq/FeauAT2HXeZquaM3Qm4wbuw=",
+        "lastModified": 1743254817,
+        "narHash": "sha256-Kmw/BG4Ns/5YL1GE5u75T8s2hF3c4QhuIoHWGsQ5dMI=",
         "owner": "madsbv",
         "repo": "nix-options-search",
-        "rev": "fad08278c264f5bfd26141522b8910413c77fd7c",
+        "rev": "6cb84b29ea3c83df2a7a847cd42ff4ece9385dea",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743215516,
-        "narHash": "sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL+9TWv2UDCEPNI=",
+        "lastModified": 1743302122,
+        "narHash": "sha256-VWyaUfBY49kjN29N140INa9LEW0YIgAr+OEJRdbKfnQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "524463199fdee49338006b049bc376b965a2cfed",
+        "rev": "15c2a7930e04efc87be3ebf1b5d06232e635e24b",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742700801,
-        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
+        "lastModified": 1743305778,
+        "narHash": "sha256-Ux/UohNtnM5mn9SFjaHp6IZe2aAnUCzklMluNtV6zFo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
+        "rev": "8e873886bbfc32163fe027b8676c75637b7da114",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sun Mar 30 05:13:52 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/70947c1908108c0c551ddfd73d4f750ff2ea67cd' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/9e624b5dfe54b7d8523d55313c22a5ef54659540' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/717030011980e9eb31eb8ce011261dd532bce92c' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/69a874c5070f9e718a9b2c125cafc0ffc4b5babf' into the Git cache...
unpacking 'github:LnL7/nix-darwin/53d0f0ed11487a4476741fde757d0feabef4cc4e' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/47f55ed32b2820259cd4c196b759086e9dd82b9e' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04' into the Git cache...
unpacking 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea' into the Git cache...
unpacking 'github:oxalica/rust-overlay/15c2a7930e04efc87be3ebf1b5d06232e635e24b' into the Git cache...
unpacking 'github:Mic92/sops-nix/8e873886bbfc32163fe027b8676c75637b7da114' into the Git cache...
unpacking 'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/1efd2503172016a6742c87b47b43ca2c8145607d?narHash=sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54%3D' (2025-03-28)
  → 'github:nix-community/home-manager/717030011980e9eb31eb8ce011261dd532bce92c?narHash=sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ%3D' (2025-03-30)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6?narHash=sha256-AulwPVrS9859t%2BeJ61v24wH/nfBEIDSXYxlRo3fL/SA%3D' (2025-03-23)
  → 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d?narHash=sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E%3D' (2025-03-30)
• Updated input 'nix-versions':
    'github:vic/nix-versions/c5da13738d7dacfecd7ff33528857e2039795123?narHash=sha256-3Pk3yttLli8AFZ695I/zrUX8GNb1FNTbT8CdyRRf%2BpE%3D' (2025-03-28)
  → 'github:vic/nix-versions/47f55ed32b2820259cd4c196b759086e9dd82b9e?narHash=sha256-7Q3Akhh0DrpxZ5ifoV2Z%2BvcWT1vYhFFs2JncJneBGMQ%3D' (2025-03-30)
• Updated input 'nox':
    'github:madsbv/nix-options-search/fad08278c264f5bfd26141522b8910413c77fd7c?narHash=sha256-bDrZUOuzPaNhvyeLwKq/FeauAT2HXeZquaM3Qm4wbuw%3D' (2025-03-14)
  → 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea?narHash=sha256-Kmw/BG4Ns/5YL1GE5u75T8s2hF3c4QhuIoHWGsQ5dMI%3D' (2025-03-29)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/524463199fdee49338006b049bc376b965a2cfed?narHash=sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL%2B9TWv2UDCEPNI%3D' (2025-03-29)
  → 'github:oxalica/rust-overlay/15c2a7930e04efc87be3ebf1b5d06232e635e24b?narHash=sha256-VWyaUfBY49kjN29N140INa9LEW0YIgAr%2BOEJRdbKfnQ%3D' (2025-03-30)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/67566fe68a8bed2a7b1175fdfb0697ed22ae8852?narHash=sha256-ZGlpUDsuBdeZeTNgoMv%2Baw0ByXT2J3wkYw9kJwkAS4M%3D' (2025-03-23)
  → 'github:Mic92/sops-nix/8e873886bbfc32163fe027b8676c75637b7da114?narHash=sha256-Ux/UohNtnM5mn9SFjaHp6IZe2aAnUCzklMluNtV6zFo%3D' (2025-03-30)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
