### PR TITLE
Updating flake inputs Mon Mar 31 05:15:49 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743147083,
-        "narHash": "sha256-KoZKa2eP438dU27YsG40Xjg8EeRPfcJ0NmF7stz2BgI=",
+        "lastModified": 1743397358,
+        "narHash": "sha256-zpgNDXyo+xm/EzWJZfDmI98By93xM6ztIF7QXuqWLxs=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "9e624b5dfe54b7d8523d55313c22a5ef54659540",
+        "rev": "9be19e20dc1e5a20289715223ce3141b5a348e1d",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743295846,
-        "narHash": "sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ=",
+        "lastModified": 1743360001,
+        "narHash": "sha256-HtpS/ZdgWXw0y+aFdORcX5RuBGTyz3WskThspNR70SM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "717030011980e9eb31eb8ce011261dd532bce92c",
+        "rev": "b6fd653ef8fbeccfd4958650757e91767a65506d",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743142629,
-        "narHash": "sha256-SIwwnO0dbpVzyanXe4ecKe/axg2LNRc3qEpIbWo8gKo=",
+        "lastModified": 1743315340,
+        "narHash": "sha256-d3SjmZUP774FChWMyy8fwnis797oAy75STc1+dM9lMQ=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "69a874c5070f9e718a9b2c125cafc0ffc4b5babf",
+        "rev": "82ff029f5f3ef46ab70c4f9c1d9e3d584108818d",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743221873,
-        "narHash": "sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs=",
+        "lastModified": 1743350051,
+        "narHash": "sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "53d0f0ed11487a4476741fde757d0feabef4cc4e",
+        "rev": "eaff8219d629bb86e71e3274e1b7915014e7fb22",
         "type": "github"
       },
       "original": {
@@ -470,11 +470,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743311161,
-        "narHash": "sha256-7Q3Akhh0DrpxZ5ifoV2Z+vcWT1vYhFFs2JncJneBGMQ=",
+        "lastModified": 1743398099,
+        "narHash": "sha256-3XX7Xege9EAumJ88zI1uNm8+5Y5IYTnJTIQfFBCLPzU=",
         "owner": "vic",
         "repo": "nix-versions",
-        "rev": "47f55ed32b2820259cd4c196b759086e9dd82b9e",
+        "rev": "fc8daa91556d2274cf1b72b533e2b5f1fdea6964",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743076231,
-        "narHash": "sha256-yQugdVfi316qUfqzN8JMaA2vixl+45GxNm4oUfXlbgw=",
+        "lastModified": 1743259260,
+        "narHash": "sha256-ArWLUgRm1tKHiqlhnymyVqi5kLNCK5ghvm06mfCl4QY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c5963357f3c1c840201eda129a99d455074db04",
+        "rev": "eb0e0f21f15c559d2ac7633dc81d079d1caf5f5f",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743302122,
-        "narHash": "sha256-VWyaUfBY49kjN29N140INa9LEW0YIgAr+OEJRdbKfnQ=",
+        "lastModified": 1743388531,
+        "narHash": "sha256-OBcNE+2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "15c2a7930e04efc87be3ebf1b5d06232e635e24b",
+        "rev": "011de3c895927300651d9c2cb8e062adf17aa665",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Mon Mar 31 05:15:49 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/70947c1908108c0c551ddfd73d4f750ff2ea67cd' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/9be19e20dc1e5a20289715223ce3141b5a348e1d' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/b6fd653ef8fbeccfd4958650757e91767a65506d' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/82ff029f5f3ef46ab70c4f9c1d9e3d584108818d' into the Git cache...
unpacking 'github:LnL7/nix-darwin/eaff8219d629bb86e71e3274e1b7915014e7fb22' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/fc8daa91556d2274cf1b72b533e2b5f1fdea6964' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/eb0e0f21f15c559d2ac7633dc81d079d1caf5f5f' into the Git cache...
unpacking 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea' into the Git cache...
unpacking 'github:oxalica/rust-overlay/011de3c895927300651d9c2cb8e062adf17aa665' into the Git cache...
unpacking 'github:Mic92/sops-nix/8e873886bbfc32163fe027b8676c75637b7da114' into the Git cache...
unpacking 'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/9e624b5dfe54b7d8523d55313c22a5ef54659540?narHash=sha256-KoZKa2eP438dU27YsG40Xjg8EeRPfcJ0NmF7stz2BgI%3D' (2025-03-28)
  → 'github:doomemacs/doomemacs/9be19e20dc1e5a20289715223ce3141b5a348e1d?narHash=sha256-zpgNDXyo%2Bxm/EzWJZfDmI98By93xM6ztIF7QXuqWLxs%3D' (2025-03-31)
• Updated input 'home-manager':
    'github:nix-community/home-manager/717030011980e9eb31eb8ce011261dd532bce92c?narHash=sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ%3D' (2025-03-30)
  → 'github:nix-community/home-manager/b6fd653ef8fbeccfd4958650757e91767a65506d?narHash=sha256-HtpS/ZdgWXw0y%2BaFdORcX5RuBGTyz3WskThspNR70SM%3D' (2025-03-30)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/69a874c5070f9e718a9b2c125cafc0ffc4b5babf?narHash=sha256-SIwwnO0dbpVzyanXe4ecKe/axg2LNRc3qEpIbWo8gKo%3D' (2025-03-28)
  → 'github:yusdacra/nix-cargo-integration/82ff029f5f3ef46ab70c4f9c1d9e3d584108818d?narHash=sha256-d3SjmZUP774FChWMyy8fwnis797oAy75STc1%2BdM9lMQ%3D' (2025-03-30)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/53d0f0ed11487a4476741fde757d0feabef4cc4e?narHash=sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs%3D' (2025-03-29)
  → 'github:LnL7/nix-darwin/eaff8219d629bb86e71e3274e1b7915014e7fb22?narHash=sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk%3D' (2025-03-30)
• Updated input 'nix-versions':
    'github:vic/nix-versions/47f55ed32b2820259cd4c196b759086e9dd82b9e?narHash=sha256-7Q3Akhh0DrpxZ5ifoV2Z%2BvcWT1vYhFFs2JncJneBGMQ%3D' (2025-03-30)
  → 'github:vic/nix-versions/fc8daa91556d2274cf1b72b533e2b5f1fdea6964?narHash=sha256-3XX7Xege9EAumJ88zI1uNm8%2B5Y5IYTnJTIQfFBCLPzU%3D' (2025-03-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04?narHash=sha256-yQugdVfi316qUfqzN8JMaA2vixl%2B45GxNm4oUfXlbgw%3D' (2025-03-27)
  → 'github:nixos/nixpkgs/eb0e0f21f15c559d2ac7633dc81d079d1caf5f5f?narHash=sha256-ArWLUgRm1tKHiqlhnymyVqi5kLNCK5ghvm06mfCl4QY%3D' (2025-03-29)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/15c2a7930e04efc87be3ebf1b5d06232e635e24b?narHash=sha256-VWyaUfBY49kjN29N140INa9LEW0YIgAr%2BOEJRdbKfnQ%3D' (2025-03-30)
  → 'github:oxalica/rust-overlay/011de3c895927300651d9c2cb8e062adf17aa665?narHash=sha256-OBcNE%2B2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc%3D' (2025-03-31)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
