### PR TITLE
Updating flake inputs Tue Apr  1 05:15:37 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743147083,
-        "narHash": "sha256-KoZKa2eP438dU27YsG40Xjg8EeRPfcJ0NmF7stz2BgI=",
+        "lastModified": 1743482852,
+        "narHash": "sha256-fjMvCNKRr+UDvk5nXQVtWEvUcs15dy1E2z+Fd2/0vXE=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "9e624b5dfe54b7d8523d55313c22a5ef54659540",
+        "rev": "d775ed822cf14d4c71dffab2f087e49000f69ff0",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743295846,
-        "narHash": "sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ=",
+        "lastModified": 1743482579,
+        "narHash": "sha256-u81nqA4UuRatKDkzUuIfVYdLMw8birEy+99oXpdyXhY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "717030011980e9eb31eb8ce011261dd532bce92c",
+        "rev": "c21383b556609ce1ad901aa08b4c6fbd9e0c7af0",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743142629,
-        "narHash": "sha256-SIwwnO0dbpVzyanXe4ecKe/axg2LNRc3qEpIbWo8gKo=",
+        "lastModified": 1743401870,
+        "narHash": "sha256-0VboQlxCjWXGqbG18PoHy0Buwa91tq2zlrISVIiIm8E=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "69a874c5070f9e718a9b2c125cafc0ffc4b5babf",
+        "rev": "a742cee73dbb4ad3df342ed4ddc9ad9577597f10",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743221873,
-        "narHash": "sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs=",
+        "lastModified": 1743350051,
+        "narHash": "sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "53d0f0ed11487a4476741fde757d0feabef4cc4e",
+        "rev": "eaff8219d629bb86e71e3274e1b7915014e7fb22",
         "type": "github"
       },
       "original": {
@@ -470,11 +470,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743311161,
-        "narHash": "sha256-7Q3Akhh0DrpxZ5ifoV2Z+vcWT1vYhFFs2JncJneBGMQ=",
+        "lastModified": 1743456002,
+        "narHash": "sha256-SyaXOBD4OdRZhIFfRaesfyYhNz2mBjV/u4PqZnqGGo4=",
         "owner": "vic",
         "repo": "nix-versions",
-        "rev": "47f55ed32b2820259cd4c196b759086e9dd82b9e",
+        "rev": "efcacb493879d7c4a0f30d6e6206917885a9f3a4",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743076231,
-        "narHash": "sha256-yQugdVfi316qUfqzN8JMaA2vixl+45GxNm4oUfXlbgw=",
+        "lastModified": 1743320628,
+        "narHash": "sha256-FurMxmjEEqEMld11eX2vgfAx0Rz0JhoFm8UgxbfCZa8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c5963357f3c1c840201eda129a99d455074db04",
+        "rev": "63158b9cbb6ec93d26255871c447b0f01da81619",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743302122,
-        "narHash": "sha256-VWyaUfBY49kjN29N140INa9LEW0YIgAr+OEJRdbKfnQ=",
+        "lastModified": 1743475035,
+        "narHash": "sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "15c2a7930e04efc87be3ebf1b5d06232e635e24b",
+        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Tue Apr  1 05:15:37 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/70947c1908108c0c551ddfd73d4f750ff2ea67cd' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/d775ed822cf14d4c71dffab2f087e49000f69ff0' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/a742cee73dbb4ad3df342ed4ddc9ad9577597f10' into the Git cache...
unpacking 'github:LnL7/nix-darwin/eaff8219d629bb86e71e3274e1b7915014e7fb22' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/efcacb493879d7c4a0f30d6e6206917885a9f3a4' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/63158b9cbb6ec93d26255871c447b0f01da81619' into the Git cache...
unpacking 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea' into the Git cache...
unpacking 'github:oxalica/rust-overlay/bee11c51c2cda3ac57c9e0149d94b86cc1b00d13' into the Git cache...
unpacking 'github:Mic92/sops-nix/8e873886bbfc32163fe027b8676c75637b7da114' into the Git cache...
unpacking 'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/9e624b5dfe54b7d8523d55313c22a5ef54659540?narHash=sha256-KoZKa2eP438dU27YsG40Xjg8EeRPfcJ0NmF7stz2BgI%3D' (2025-03-28)
  → 'github:doomemacs/doomemacs/d775ed822cf14d4c71dffab2f087e49000f69ff0?narHash=sha256-fjMvCNKRr%2BUDvk5nXQVtWEvUcs15dy1E2z%2BFd2/0vXE%3D' (2025-04-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/717030011980e9eb31eb8ce011261dd532bce92c?narHash=sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ%3D' (2025-03-30)
  → 'github:nix-community/home-manager/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0?narHash=sha256-u81nqA4UuRatKDkzUuIfVYdLMw8birEy%2B99oXpdyXhY%3D' (2025-04-01)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/69a874c5070f9e718a9b2c125cafc0ffc4b5babf?narHash=sha256-SIwwnO0dbpVzyanXe4ecKe/axg2LNRc3qEpIbWo8gKo%3D' (2025-03-28)
  → 'github:yusdacra/nix-cargo-integration/a742cee73dbb4ad3df342ed4ddc9ad9577597f10?narHash=sha256-0VboQlxCjWXGqbG18PoHy0Buwa91tq2zlrISVIiIm8E%3D' (2025-03-31)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/53d0f0ed11487a4476741fde757d0feabef4cc4e?narHash=sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs%3D' (2025-03-29)
  → 'github:LnL7/nix-darwin/eaff8219d629bb86e71e3274e1b7915014e7fb22?narHash=sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk%3D' (2025-03-30)
• Updated input 'nix-versions':
    'github:vic/nix-versions/47f55ed32b2820259cd4c196b759086e9dd82b9e?narHash=sha256-7Q3Akhh0DrpxZ5ifoV2Z%2BvcWT1vYhFFs2JncJneBGMQ%3D' (2025-03-30)
  → 'github:vic/nix-versions/efcacb493879d7c4a0f30d6e6206917885a9f3a4?narHash=sha256-SyaXOBD4OdRZhIFfRaesfyYhNz2mBjV/u4PqZnqGGo4%3D' (2025-03-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04?narHash=sha256-yQugdVfi316qUfqzN8JMaA2vixl%2B45GxNm4oUfXlbgw%3D' (2025-03-27)
  → 'github:nixos/nixpkgs/63158b9cbb6ec93d26255871c447b0f01da81619?narHash=sha256-FurMxmjEEqEMld11eX2vgfAx0Rz0JhoFm8UgxbfCZa8%3D' (2025-03-30)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/15c2a7930e04efc87be3ebf1b5d06232e635e24b?narHash=sha256-VWyaUfBY49kjN29N140INa9LEW0YIgAr%2BOEJRdbKfnQ%3D' (2025-03-30)
  → 'github:oxalica/rust-overlay/bee11c51c2cda3ac57c9e0149d94b86cc1b00d13?narHash=sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4%3D' (2025-04-01)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
