### PR TITLE
Updating flake inputs Wed Apr  2 05:16:17 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743482852,
-        "narHash": "sha256-fjMvCNKRr+UDvk5nXQVtWEvUcs15dy1E2z+Fd2/0vXE=",
+        "lastModified": 1743544693,
+        "narHash": "sha256-HDakX8t3oQ4JD9Kw92wNywzP8s90dJgSsnoEV6No5oU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "d775ed822cf14d4c71dffab2f087e49000f69ff0",
+        "rev": "52c385c033f627d2f2caf74a223adefed7aaf6d7",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743482579,
-        "narHash": "sha256-u81nqA4UuRatKDkzUuIfVYdLMw8birEy+99oXpdyXhY=",
+        "lastModified": 1743556466,
+        "narHash": "sha256-rvU79DJ6rPDxiH0sTp686Vlm+JewwAZPGcwt8OfHJbM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c21383b556609ce1ad901aa08b4c6fbd9e0c7af0",
+        "rev": "5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743401870,
-        "narHash": "sha256-0VboQlxCjWXGqbG18PoHy0Buwa91tq2zlrISVIiIm8E=",
+        "lastModified": 1743488269,
+        "narHash": "sha256-G4IRYK7vG2kA9Xr1KwXJH1SVc57qNPlQXBl6d/V6LSc=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "a742cee73dbb4ad3df342ed4ddc9ad9577597f10",
+        "rev": "be686c02a3fbad61448abcc2049a9178a4cd903c",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743350051,
-        "narHash": "sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk=",
+        "lastModified": 1743496612,
+        "narHash": "sha256-emPWa5lmKbnyuj8c1mSJUkzJNT+iJoU9GMcXwjp2oVM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "eaff8219d629bb86e71e3274e1b7915014e7fb22",
+        "rev": "73d59580d01e9b9f957ba749f336a272869c42dd",
         "type": "github"
       },
       "original": {
@@ -470,11 +470,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743456002,
-        "narHash": "sha256-SyaXOBD4OdRZhIFfRaesfyYhNz2mBjV/u4PqZnqGGo4=",
+        "lastModified": 1743555218,
+        "narHash": "sha256-ha2QzaHR58g0cY3EcFQ3scq5Sv2ZOmwOsVuN2jcc/Bs=",
         "owner": "vic",
         "repo": "nix-versions",
-        "rev": "efcacb493879d7c4a0f30d6e6206917885a9f3a4",
+        "rev": "04ca471073510af702d75759fd6b3dcb833dfbb2",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743320628,
-        "narHash": "sha256-FurMxmjEEqEMld11eX2vgfAx0Rz0JhoFm8UgxbfCZa8=",
+        "lastModified": 1743538100,
+        "narHash": "sha256-Bl/ynRPIb4CdtbEw3gfJYpKiHmRmrKltXc8zipqpO0o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63158b9cbb6ec93d26255871c447b0f01da81619",
+        "rev": "b9d43b3fe5152d1dc5783a2ba865b2a03388b741",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743475035,
-        "narHash": "sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4=",
+        "lastModified": 1743561237,
+        "narHash": "sha256-dd97LXek202OWmUXvKYFdYWj0jHrn3p+L5Ojh1SEOqs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
+        "rev": "1de27ae43712a971c1da100dcd84386356f03ec7",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743305778,
-        "narHash": "sha256-Ux/UohNtnM5mn9SFjaHp6IZe2aAnUCzklMluNtV6zFo=",
+        "lastModified": 1743502316,
+        "narHash": "sha256-zI2WSkU+ei4zCxT+IVSQjNM9i0ST++T2qSFXTsAND7s=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8e873886bbfc32163fe027b8676c75637b7da114",
+        "rev": "e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Apr  2 05:16:17 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/70947c1908108c0c551ddfd73d4f750ff2ea67cd' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/52c385c033f627d2f2caf74a223adefed7aaf6d7' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/be686c02a3fbad61448abcc2049a9178a4cd903c' into the Git cache...
unpacking 'github:LnL7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/04ca471073510af702d75759fd6b3dcb833dfbb2' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/b9d43b3fe5152d1dc5783a2ba865b2a03388b741' into the Git cache...
unpacking 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea' into the Git cache...
unpacking 'github:oxalica/rust-overlay/1de27ae43712a971c1da100dcd84386356f03ec7' into the Git cache...
unpacking 'github:Mic92/sops-nix/e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8' into the Git cache...
unpacking 'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/d775ed822cf14d4c71dffab2f087e49000f69ff0?narHash=sha256-fjMvCNKRr%2BUDvk5nXQVtWEvUcs15dy1E2z%2BFd2/0vXE%3D' (2025-04-01)
  → 'github:doomemacs/doomemacs/52c385c033f627d2f2caf74a223adefed7aaf6d7?narHash=sha256-HDakX8t3oQ4JD9Kw92wNywzP8s90dJgSsnoEV6No5oU%3D' (2025-04-01)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9?narHash=sha256-%2Bu2UunDA4Cl5Fci3m7S643HzKmIDAe%2BfiXrLqYsR2fs%3D' (2025-03-07)
  → 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/147dee35aab2193b174e4c0868bd80ead5ce755c?narHash=sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk%3D' (2025-03-02)
  → 'github:nix-community/nixpkgs.lib/e4822aea2a6d1cdd36653c134cacfd64c97ff4fa?narHash=sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc%3D' (2025-03-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0?narHash=sha256-u81nqA4UuRatKDkzUuIfVYdLMw8birEy%2B99oXpdyXhY%3D' (2025-04-01)
  → 'github:nix-community/home-manager/5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0?narHash=sha256-rvU79DJ6rPDxiH0sTp686Vlm%2BJewwAZPGcwt8OfHJbM%3D' (2025-04-02)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/a742cee73dbb4ad3df342ed4ddc9ad9577597f10?narHash=sha256-0VboQlxCjWXGqbG18PoHy0Buwa91tq2zlrISVIiIm8E%3D' (2025-03-31)
  → 'github:yusdacra/nix-cargo-integration/be686c02a3fbad61448abcc2049a9178a4cd903c?narHash=sha256-G4IRYK7vG2kA9Xr1KwXJH1SVc57qNPlQXBl6d/V6LSc%3D' (2025-04-01)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/eaff8219d629bb86e71e3274e1b7915014e7fb22?narHash=sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk%3D' (2025-03-30)
  → 'github:LnL7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd?narHash=sha256-emPWa5lmKbnyuj8c1mSJUkzJNT%2BiJoU9GMcXwjp2oVM%3D' (2025-04-01)
• Updated input 'nix-versions':
    'github:vic/nix-versions/efcacb493879d7c4a0f30d6e6206917885a9f3a4?narHash=sha256-SyaXOBD4OdRZhIFfRaesfyYhNz2mBjV/u4PqZnqGGo4%3D' (2025-03-31)
  → 'github:vic/nix-versions/04ca471073510af702d75759fd6b3dcb833dfbb2?narHash=sha256-ha2QzaHR58g0cY3EcFQ3scq5Sv2ZOmwOsVuN2jcc/Bs%3D' (2025-04-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/63158b9cbb6ec93d26255871c447b0f01da81619?narHash=sha256-FurMxmjEEqEMld11eX2vgfAx0Rz0JhoFm8UgxbfCZa8%3D' (2025-03-30)
  → 'github:nixos/nixpkgs/b9d43b3fe5152d1dc5783a2ba865b2a03388b741?narHash=sha256-Bl/ynRPIb4CdtbEw3gfJYpKiHmRmrKltXc8zipqpO0o%3D' (2025-04-01)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/bee11c51c2cda3ac57c9e0149d94b86cc1b00d13?narHash=sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4%3D' (2025-04-01)
  → 'github:oxalica/rust-overlay/1de27ae43712a971c1da100dcd84386356f03ec7?narHash=sha256-dd97LXek202OWmUXvKYFdYWj0jHrn3p%2BL5Ojh1SEOqs%3D' (2025-04-02)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8e873886bbfc32163fe027b8676c75637b7da114?narHash=sha256-Ux/UohNtnM5mn9SFjaHp6IZe2aAnUCzklMluNtV6zFo%3D' (2025-03-30)
  → 'github:Mic92/sops-nix/e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8?narHash=sha256-zI2WSkU%2Bei4zCxT%2BIVSQjNM9i0ST%2B%2BT2qSFXTsAND7s%3D' (2025-04-01)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
