### PR TITLE
Updating flake inputs Thu Apr  3 05:15:21 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1742394900,
-        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
+        "lastModified": 1743649204,
+        "narHash": "sha256-uourC72krB5YdGzpHaXOUBXaORkcabPNF+H7sMvZKsw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
+        "rev": "8b9ee4e59a737b1dbefbd398caae8595ecffcf6a",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743544693,
-        "narHash": "sha256-HDakX8t3oQ4JD9Kw92wNywzP8s90dJgSsnoEV6No5oU=",
+        "lastModified": 1743635051,
+        "narHash": "sha256-5vYR4sn6t1DaHdjsgeRWqKWEweSc1T8Zk06Yawu3bEU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "52c385c033f627d2f2caf74a223adefed7aaf6d7",
+        "rev": "061189953d1d8955d8b42eef3020fe654e8481f1",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743556466,
-        "narHash": "sha256-rvU79DJ6rPDxiH0sTp686Vlm+JewwAZPGcwt8OfHJbM=",
+        "lastModified": 1743648554,
+        "narHash": "sha256-23JFd+zd2GamTTdnGuFVeIg8x8C3hLpQJRh/PGTORzo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0",
+        "rev": "107352dde4ff3c01cb5a0b3fe17f5beef37215bc",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743488269,
-        "narHash": "sha256-G4IRYK7vG2kA9Xr1KwXJH1SVc57qNPlQXBl6d/V6LSc=",
+        "lastModified": 1743574643,
+        "narHash": "sha256-uVGm2Mq9BvsmuScMr9hrEeTT2UCkuj4mtRZ40XPSvHI=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "be686c02a3fbad61448abcc2049a9178a4cd903c",
+        "rev": "a22986ee1d548079217143d8135cd231ff2bc92a",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743538100,
-        "narHash": "sha256-Bl/ynRPIb4CdtbEw3gfJYpKiHmRmrKltXc8zipqpO0o=",
+        "lastModified": 1743568003,
+        "narHash": "sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om+vQOREwiX0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b9d43b3fe5152d1dc5783a2ba865b2a03388b741",
+        "rev": "b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743561237,
-        "narHash": "sha256-dd97LXek202OWmUXvKYFdYWj0jHrn3p+L5Ojh1SEOqs=",
+        "lastModified": 1743647602,
+        "narHash": "sha256-fXd8fA6HR7MlUJQzz31zjBzUji4HpGCJ7CMVKSZOe8c=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1de27ae43712a971c1da100dcd84386356f03ec7",
+        "rev": "5b2d60b2e25bcb498103f6fae08da561f6b671da",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743502316,
-        "narHash": "sha256-zI2WSkU+ei4zCxT+IVSQjNM9i0ST++T2qSFXTsAND7s=",
+        "lastModified": 1743604509,
+        "narHash": "sha256-Hf5aYGP3hP+uNbcd4NrEMUAR+1o518uGzoeVyMzzJwo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8",
+        "rev": "4521de68fba1a36fae8caebce3d6e047179661f7",
         "type": "github"
       },
       "original": {
@@ -762,11 +762,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743081648,
-        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
+        "lastModified": 1743589519,
+        "narHash": "sha256-iBzr7Zb11nQxwX90bO1+Bm1MGlhMSmu4ixgnQFB+j4E=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
+        "rev": "18bed671738e36c5504e188aadc18b7e2a6e408f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Apr  3 05:15:21 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/8b9ee4e59a737b1dbefbd398caae8595ecffcf6a' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/061189953d1d8955d8b42eef3020fe654e8481f1' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/107352dde4ff3c01cb5a0b3fe17f5beef37215bc' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/a22986ee1d548079217143d8135cd231ff2bc92a' into the Git cache...
unpacking 'github:LnL7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/04ca471073510af702d75759fd6b3dcb833dfbb2' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76' into the Git cache...
unpacking 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea' into the Git cache...
unpacking 'github:oxalica/rust-overlay/5b2d60b2e25bcb498103f6fae08da561f6b671da' into the Git cache...
unpacking 'github:Mic92/sops-nix/4521de68fba1a36fae8caebce3d6e047179661f7' into the Git cache...
unpacking 'github:numtide/treefmt-nix/18bed671738e36c5504e188aadc18b7e2a6e408f' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/70947c1908108c0c551ddfd73d4f750ff2ea67cd?narHash=sha256-vVOAp9ahvnU%2BfQoKd4SEXB2JG2wbENkpqcwlkIXgUC0%3D' (2025-03-19)
  → 'github:ipetkov/crane/8b9ee4e59a737b1dbefbd398caae8595ecffcf6a?narHash=sha256-uourC72krB5YdGzpHaXOUBXaORkcabPNF%2BH7sMvZKsw%3D' (2025-04-03)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/52c385c033f627d2f2caf74a223adefed7aaf6d7?narHash=sha256-HDakX8t3oQ4JD9Kw92wNywzP8s90dJgSsnoEV6No5oU%3D' (2025-04-01)
  → 'github:doomemacs/doomemacs/061189953d1d8955d8b42eef3020fe654e8481f1?narHash=sha256-5vYR4sn6t1DaHdjsgeRWqKWEweSc1T8Zk06Yawu3bEU%3D' (2025-04-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0?narHash=sha256-rvU79DJ6rPDxiH0sTp686Vlm%2BJewwAZPGcwt8OfHJbM%3D' (2025-04-02)
  → 'github:nix-community/home-manager/107352dde4ff3c01cb5a0b3fe17f5beef37215bc?narHash=sha256-23JFd%2Bzd2GamTTdnGuFVeIg8x8C3hLpQJRh/PGTORzo%3D' (2025-04-03)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/be686c02a3fbad61448abcc2049a9178a4cd903c?narHash=sha256-G4IRYK7vG2kA9Xr1KwXJH1SVc57qNPlQXBl6d/V6LSc%3D' (2025-04-01)
  → 'github:yusdacra/nix-cargo-integration/a22986ee1d548079217143d8135cd231ff2bc92a?narHash=sha256-uVGm2Mq9BvsmuScMr9hrEeTT2UCkuj4mtRZ40XPSvHI%3D' (2025-04-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b9d43b3fe5152d1dc5783a2ba865b2a03388b741?narHash=sha256-Bl/ynRPIb4CdtbEw3gfJYpKiHmRmrKltXc8zipqpO0o%3D' (2025-04-01)
  → 'github:nixos/nixpkgs/b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76?narHash=sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om%2BvQOREwiX0%3D' (2025-04-02)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/1de27ae43712a971c1da100dcd84386356f03ec7?narHash=sha256-dd97LXek202OWmUXvKYFdYWj0jHrn3p%2BL5Ojh1SEOqs%3D' (2025-04-02)
  → 'github:oxalica/rust-overlay/5b2d60b2e25bcb498103f6fae08da561f6b671da?narHash=sha256-fXd8fA6HR7MlUJQzz31zjBzUji4HpGCJ7CMVKSZOe8c%3D' (2025-04-03)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8?narHash=sha256-zI2WSkU%2Bei4zCxT%2BIVSQjNM9i0ST%2B%2BT2qSFXTsAND7s%3D' (2025-04-01)
  → 'github:Mic92/sops-nix/4521de68fba1a36fae8caebce3d6e047179661f7?narHash=sha256-Hf5aYGP3hP%2BuNbcd4NrEMUAR%2B1o518uGzoeVyMzzJwo%3D' (2025-04-02)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7?narHash=sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE%3D' (2025-03-27)
  → 'github:numtide/treefmt-nix/18bed671738e36c5504e188aadc18b7e2a6e408f?narHash=sha256-iBzr7Zb11nQxwX90bO1%2BBm1MGlhMSmu4ixgnQFB%2Bj4E%3D' (2025-04-02)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
