### PR TITLE
Updating flake inputs Fri Apr  4 05:15:38 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1743649204,
-        "narHash": "sha256-uourC72krB5YdGzpHaXOUBXaORkcabPNF+H7sMvZKsw=",
+        "lastModified": 1743700120,
+        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b9ee4e59a737b1dbefbd398caae8595ecffcf6a",
+        "rev": "e316f19ee058e6db50075115783be57ac549c389",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743635051,
-        "narHash": "sha256-5vYR4sn6t1DaHdjsgeRWqKWEweSc1T8Zk06Yawu3bEU=",
+        "lastModified": 1743716432,
+        "narHash": "sha256-82asTsOVfNAWQ56+cANW7JkPiBc7G1oGYM2nr59mFHE=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "061189953d1d8955d8b42eef3020fe654e8481f1",
+        "rev": "b1e6dec47a2d0fa5fd8f7ab55b5f1012d16cb48b",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743648554,
-        "narHash": "sha256-23JFd+zd2GamTTdnGuFVeIg8x8C3hLpQJRh/PGTORzo=",
+        "lastModified": 1743717835,
+        "narHash": "sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "107352dde4ff3c01cb5a0b3fe17f5beef37215bc",
+        "rev": "66a6ec65f84255b3defb67ff45af86c844dd451b",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743574643,
-        "narHash": "sha256-uVGm2Mq9BvsmuScMr9hrEeTT2UCkuj4mtRZ40XPSvHI=",
+        "lastModified": 1743661054,
+        "narHash": "sha256-QDl5LTrDMs/f2z8c+5Me87C+asx1w1nfWbItiUg+3zU=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "a22986ee1d548079217143d8135cd231ff2bc92a",
+        "rev": "05537e39230cd92028ecfe114630308aa1708fc8",
         "type": "github"
       },
       "original": {
@@ -539,11 +539,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743568003,
-        "narHash": "sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om+vQOREwiX0=",
+        "lastModified": 1743689281,
+        "narHash": "sha256-y7Hg5lwWhEOgflEHRfzSH96BOt26LaYfrYWzZ+VoVdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76",
+        "rev": "2bfc080955153be0be56724be6fa5477b4eefabb",
         "type": "github"
       },
       "original": {
@@ -716,11 +716,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743647602,
-        "narHash": "sha256-fXd8fA6HR7MlUJQzz31zjBzUji4HpGCJ7CMVKSZOe8c=",
+        "lastModified": 1743682350,
+        "narHash": "sha256-S/MyKOFajCiBm5H5laoE59wB6w0NJ4wJG53iAPfYW3k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5b2d60b2e25bcb498103f6fae08da561f6b671da",
+        "rev": "c4a8327b0f25d1d81edecbb6105f74d7cf9d7382",
         "type": "github"
       },
       "original": {
@@ -796,11 +796,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743589519,
-        "narHash": "sha256-iBzr7Zb11nQxwX90bO1+Bm1MGlhMSmu4ixgnQFB+j4E=",
+        "lastModified": 1743677901,
+        "narHash": "sha256-eWZln+k+L/VHO69tUTzEmgeDWNQNKIpSUa9nqQgBrSE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "18bed671738e36c5504e188aadc18b7e2a6e408f",
+        "rev": "57dabe2a6255bd6165b2437ff6c2d1f6ee78421a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Apr  4 05:15:38 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/e316f19ee058e6db50075115783be57ac549c389' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/b1e6dec47a2d0fa5fd8f7ab55b5f1012d16cb48b' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/66a6ec65f84255b3defb67ff45af86c844dd451b' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/05537e39230cd92028ecfe114630308aa1708fc8' into the Git cache...
unpacking 'github:LnL7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/04ca471073510af702d75759fd6b3dcb833dfbb2' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/2bfc080955153be0be56724be6fa5477b4eefabb' into the Git cache...
unpacking 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea' into the Git cache...
unpacking 'github:oxalica/rust-overlay/c4a8327b0f25d1d81edecbb6105f74d7cf9d7382' into the Git cache...
unpacking 'github:Mic92/sops-nix/4521de68fba1a36fae8caebce3d6e047179661f7' into the Git cache...
unpacking 'github:numtide/treefmt-nix/57dabe2a6255bd6165b2437ff6c2d1f6ee78421a' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/8b9ee4e59a737b1dbefbd398caae8595ecffcf6a?narHash=sha256-uourC72krB5YdGzpHaXOUBXaORkcabPNF%2BH7sMvZKsw%3D' (2025-04-03)
  → 'github:ipetkov/crane/e316f19ee058e6db50075115783be57ac549c389?narHash=sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY%3D' (2025-04-03)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/061189953d1d8955d8b42eef3020fe654e8481f1?narHash=sha256-5vYR4sn6t1DaHdjsgeRWqKWEweSc1T8Zk06Yawu3bEU%3D' (2025-04-02)
  → 'github:doomemacs/doomemacs/b1e6dec47a2d0fa5fd8f7ab55b5f1012d16cb48b?narHash=sha256-82asTsOVfNAWQ56%2BcANW7JkPiBc7G1oGYM2nr59mFHE%3D' (2025-04-03)
• Updated input 'home-manager':
    'github:nix-community/home-manager/107352dde4ff3c01cb5a0b3fe17f5beef37215bc?narHash=sha256-23JFd%2Bzd2GamTTdnGuFVeIg8x8C3hLpQJRh/PGTORzo%3D' (2025-04-03)
  → 'github:nix-community/home-manager/66a6ec65f84255b3defb67ff45af86c844dd451b?narHash=sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU%3D' (2025-04-03)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/a22986ee1d548079217143d8135cd231ff2bc92a?narHash=sha256-uVGm2Mq9BvsmuScMr9hrEeTT2UCkuj4mtRZ40XPSvHI%3D' (2025-04-02)
  → 'github:yusdacra/nix-cargo-integration/05537e39230cd92028ecfe114630308aa1708fc8?narHash=sha256-QDl5LTrDMs/f2z8c%2B5Me87C%2Basx1w1nfWbItiUg%2B3zU%3D' (2025-04-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76?narHash=sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om%2BvQOREwiX0%3D' (2025-04-02)
  → 'github:nixos/nixpkgs/2bfc080955153be0be56724be6fa5477b4eefabb?narHash=sha256-y7Hg5lwWhEOgflEHRfzSH96BOt26LaYfrYWzZ%2BVoVdg%3D' (2025-04-03)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/5b2d60b2e25bcb498103f6fae08da561f6b671da?narHash=sha256-fXd8fA6HR7MlUJQzz31zjBzUji4HpGCJ7CMVKSZOe8c%3D' (2025-04-03)
  → 'github:oxalica/rust-overlay/c4a8327b0f25d1d81edecbb6105f74d7cf9d7382?narHash=sha256-S/MyKOFajCiBm5H5laoE59wB6w0NJ4wJG53iAPfYW3k%3D' (2025-04-03)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/18bed671738e36c5504e188aadc18b7e2a6e408f?narHash=sha256-iBzr7Zb11nQxwX90bO1%2BBm1MGlhMSmu4ixgnQFB%2Bj4E%3D' (2025-04-02)
  → 'github:numtide/treefmt-nix/57dabe2a6255bd6165b2437ff6c2d1f6ee78421a?narHash=sha256-eWZln%2Bk%2BL/VHO69tUTzEmgeDWNQNKIpSUa9nqQgBrSE%3D' (2025-04-03)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
