### PR TITLE
Updating flake inputs Sat Apr  5 05:15:18 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1743700120,
-        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
+        "lastModified": 1743807446,
+        "narHash": "sha256-6ERwwMADv5VW+Eq6vrKZqFnGAj5+tL4vizGDmTWJjPc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "e316f19ee058e6db50075115783be57ac549c389",
+        "rev": "b62437f7e7e11fd2b456af29c25d04734fc49aa2",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743716432,
-        "narHash": "sha256-82asTsOVfNAWQ56+cANW7JkPiBc7G1oGYM2nr59mFHE=",
+        "lastModified": 1743797543,
+        "narHash": "sha256-OdNF32UueUbJ9FPHI3AX6LClZhiGZktO145h/QgCvs4=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "b1e6dec47a2d0fa5fd8f7ab55b5f1012d16cb48b",
+        "rev": "9dfcb5401f5655168bb90fcaec5149e8c159f535",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743717835,
-        "narHash": "sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU=",
+        "lastModified": 1743788974,
+        "narHash": "sha256-2LeVyQZI2wTkSzMLvnN/kJjXVWp4HCVUoq17Bv8TNTk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66a6ec65f84255b3defb67ff45af86c844dd451b",
+        "rev": "0f5908daf890c3d7e7052bef1d6deb0f2710aaa1",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743661054,
-        "narHash": "sha256-QDl5LTrDMs/f2z8c+5Me87C+asx1w1nfWbItiUg+3zU=",
+        "lastModified": 1743747441,
+        "narHash": "sha256-eI5U0DYATbcnOLSqZkeWqVjov9lzF+jG9G/wii0M/XA=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "05537e39230cd92028ecfe114630308aa1708fc8",
+        "rev": "8770d0846c1e4e294b65f3f6a6c5a299b63264d6",
         "type": "github"
       },
       "original": {
@@ -716,11 +716,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743682350,
-        "narHash": "sha256-S/MyKOFajCiBm5H5laoE59wB6w0NJ4wJG53iAPfYW3k=",
+        "lastModified": 1743820323,
+        "narHash": "sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c4a8327b0f25d1d81edecbb6105f74d7cf9d7382",
+        "rev": "b4734ce867252f92cdc7d25f8cc3b7cef153e703",
         "type": "github"
       },
       "original": {
@@ -759,11 +759,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743604509,
-        "narHash": "sha256-Hf5aYGP3hP+uNbcd4NrEMUAR+1o518uGzoeVyMzzJwo=",
+        "lastModified": 1743756170,
+        "narHash": "sha256-2b11EYa08oqDmF3zEBLkG1AoNn9rB1k39ew/T/mSvbU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4521de68fba1a36fae8caebce3d6e047179661f7",
+        "rev": "cff8437c5fe8c68fc3a840a21bf1f4dc801da40d",
         "type": "github"
       },
       "original": {
@@ -796,11 +796,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743677901,
-        "narHash": "sha256-eWZln+k+L/VHO69tUTzEmgeDWNQNKIpSUa9nqQgBrSE=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "57dabe2a6255bd6165b2437ff6c2d1f6ee78421a",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Apr  5 05:15:18 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/b62437f7e7e11fd2b456af29c25d04734fc49aa2' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/9dfcb5401f5655168bb90fcaec5149e8c159f535' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/0f5908daf890c3d7e7052bef1d6deb0f2710aaa1' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/8770d0846c1e4e294b65f3f6a6c5a299b63264d6' into the Git cache...
unpacking 'github:LnL7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/04ca471073510af702d75759fd6b3dcb833dfbb2' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/2bfc080955153be0be56724be6fa5477b4eefabb' into the Git cache...
unpacking 'github:madsbv/nix-options-search/6cb84b29ea3c83df2a7a847cd42ff4ece9385dea' into the Git cache...
unpacking 'github:oxalica/rust-overlay/b4734ce867252f92cdc7d25f8cc3b7cef153e703' into the Git cache...
unpacking 'github:Mic92/sops-nix/cff8437c5fe8c68fc3a840a21bf1f4dc801da40d' into the Git cache...
unpacking 'github:numtide/treefmt-nix/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/e316f19ee058e6db50075115783be57ac549c389?narHash=sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY%3D' (2025-04-03)
  → 'github:ipetkov/crane/b62437f7e7e11fd2b456af29c25d04734fc49aa2?narHash=sha256-6ERwwMADv5VW%2BEq6vrKZqFnGAj5%2BtL4vizGDmTWJjPc%3D' (2025-04-04)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/b1e6dec47a2d0fa5fd8f7ab55b5f1012d16cb48b?narHash=sha256-82asTsOVfNAWQ56%2BcANW7JkPiBc7G1oGYM2nr59mFHE%3D' (2025-04-03)
  → 'github:doomemacs/doomemacs/9dfcb5401f5655168bb90fcaec5149e8c159f535?narHash=sha256-OdNF32UueUbJ9FPHI3AX6LClZhiGZktO145h/QgCvs4%3D' (2025-04-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/66a6ec65f84255b3defb67ff45af86c844dd451b?narHash=sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU%3D' (2025-04-03)
  → 'github:nix-community/home-manager/0f5908daf890c3d7e7052bef1d6deb0f2710aaa1?narHash=sha256-2LeVyQZI2wTkSzMLvnN/kJjXVWp4HCVUoq17Bv8TNTk%3D' (2025-04-04)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/05537e39230cd92028ecfe114630308aa1708fc8?narHash=sha256-QDl5LTrDMs/f2z8c%2B5Me87C%2Basx1w1nfWbItiUg%2B3zU%3D' (2025-04-03)
  → 'github:yusdacra/nix-cargo-integration/8770d0846c1e4e294b65f3f6a6c5a299b63264d6?narHash=sha256-eI5U0DYATbcnOLSqZkeWqVjov9lzF%2BjG9G/wii0M/XA%3D' (2025-04-04)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/c4a8327b0f25d1d81edecbb6105f74d7cf9d7382?narHash=sha256-S/MyKOFajCiBm5H5laoE59wB6w0NJ4wJG53iAPfYW3k%3D' (2025-04-03)
  → 'github:oxalica/rust-overlay/b4734ce867252f92cdc7d25f8cc3b7cef153e703?narHash=sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY%3D' (2025-04-05)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/4521de68fba1a36fae8caebce3d6e047179661f7?narHash=sha256-Hf5aYGP3hP%2BuNbcd4NrEMUAR%2B1o518uGzoeVyMzzJwo%3D' (2025-04-02)
  → 'github:Mic92/sops-nix/cff8437c5fe8c68fc3a840a21bf1f4dc801da40d?narHash=sha256-2b11EYa08oqDmF3zEBLkG1AoNn9rB1k39ew/T/mSvbU%3D' (2025-04-04)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/57dabe2a6255bd6165b2437ff6c2d1f6ee78421a?narHash=sha256-eWZln%2Bk%2BL/VHO69tUTzEmgeDWNQNKIpSUa9nqQgBrSE%3D' (2025-04-03)
  → 'github:numtide/treefmt-nix/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d?narHash=sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660%2BgbUU3cE%3D' (2025-04-04)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
