### PR TITLE
Updating flake inputs Mon Apr  7 05:16:03 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743912279,
-        "narHash": "sha256-94E3HFKl/EeUTRPJPlGikrFK5wJxCAjr2BvENf7uS1s=",
+        "lastModified": 1743979010,
+        "narHash": "sha256-cw6j4Oq4zzwFEhaOgZ69ngdN3KvcT7nafhkfwzBDxNw=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "90b64a031395711f97c8dd5e52415a8848775ddd",
+        "rev": "b840f902525f02db345508b156fe4585bf877e2b",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743869639,
-        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
+        "lastModified": 1743998782,
+        "narHash": "sha256-gckmtwW/H0jEM1Y8G3wBLfr2nJvwBdjuqnjKNV0lcQY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
+        "rev": "c15ab0ce0dbe64843358a3081b09ed35144dfd65",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1743894856,
-        "narHash": "sha256-yNP14Kge9bb6MAuOEVbBFf0W1QhNkvYDb2IJgjezaMg=",
+        "lastModified": 1743953935,
+        "narHash": "sha256-WHrp01Pi68QCBJjLij58cvD5lqjpqGyGZzoaXeHxp5M=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "2adce6679e5cda837f2379b1e1b42517513f055d",
+        "rev": "91637732ebb5918c688e665e7407c2eed8b4ba10",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743833727,
-        "narHash": "sha256-mtpvT+bvzd2HIxa4BYkiRZaArRzLMbYk3JwFKC6Xpkw=",
+        "lastModified": 1743920150,
+        "narHash": "sha256-SqT5qH1zEh2CUHpQmZNLqZkZB7bAhV6rb28nZ5tiTz0=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "e21b0a9f7196b37a45e5d6ed42bc2e3b9d1084a8",
+        "rev": "ac4e870a6ea6423347c2a13fc59333251f0a93b0",
         "type": "github"
       },
       "original": {
@@ -555,11 +555,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743689281,
-        "narHash": "sha256-y7Hg5lwWhEOgflEHRfzSH96BOt26LaYfrYWzZ+VoVdg=",
+        "lastModified": 1743814133,
+        "narHash": "sha256-drDyYyUmjeYGiHmwB9eOPTQRjmrq3Yz26knwmMPLZFk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2bfc080955153be0be56724be6fa5477b4eefabb",
+        "rev": "250b695f41e0e2f5afbf15c6b12480de1fe0001b",
         "type": "github"
       },
       "original": {
@@ -733,11 +733,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743906877,
-        "narHash": "sha256-Thah1oU8Vy0gs9bh5QhNcQh1iuQiowMnZPbrkURonZA=",
+        "lastModified": 1743993291,
+        "narHash": "sha256-u8GHvduU1gCtoFXvTS/wGjH1ouv5S/GRGq6MAT+sG/k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9d00c6b69408dd40d067603012938d9fbe95cfcd",
+        "rev": "0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Mon Apr  7 05:16:03 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/80ceeec0dc94ef967c371dcdc56adb280328f591' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/b840f902525f02db345508b156fe4585bf877e2b' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/c15ab0ce0dbe64843358a3081b09ed35144dfd65' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/91637732ebb5918c688e665e7407c2eed8b4ba10' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/ac4e870a6ea6423347c2a13fc59333251f0a93b0' into the Git cache...
unpacking 'github:LnL7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd' into the Git cache...
unpacking 'github:nix-community/nix-index-database/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/04ca471073510af702d75759fd6b3dcb833dfbb2' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/250b695f41e0e2f5afbf15c6b12480de1fe0001b' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b' into the Git cache...
unpacking 'github:Mic92/sops-nix/523f58a4faff6c67f5f685bed33a7721e984c304' into the Git cache...
unpacking 'github:numtide/treefmt-nix/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/90b64a031395711f97c8dd5e52415a8848775ddd?narHash=sha256-94E3HFKl/EeUTRPJPlGikrFK5wJxCAjr2BvENf7uS1s%3D' (2025-04-06)
  → 'github:doomemacs/doomemacs/b840f902525f02db345508b156fe4585bf877e2b?narHash=sha256-cw6j4Oq4zzwFEhaOgZ69ngdN3KvcT7nafhkfwzBDxNw%3D' (2025-04-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d094c6763c6ddb860580e7d3b4201f8f496a6836?narHash=sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ%3D' (2025-04-05)
  → 'github:nix-community/home-manager/c15ab0ce0dbe64843358a3081b09ed35144dfd65?narHash=sha256-gckmtwW/H0jEM1Y8G3wBLfr2nJvwBdjuqnjKNV0lcQY%3D' (2025-04-07)
• Updated input 'jjui':
    'github:idursun/jjui/2adce6679e5cda837f2379b1e1b42517513f055d?narHash=sha256-yNP14Kge9bb6MAuOEVbBFf0W1QhNkvYDb2IJgjezaMg%3D' (2025-04-05)
  → 'github:idursun/jjui/91637732ebb5918c688e665e7407c2eed8b4ba10?narHash=sha256-WHrp01Pi68QCBJjLij58cvD5lqjpqGyGZzoaXeHxp5M%3D' (2025-04-06)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/e21b0a9f7196b37a45e5d6ed42bc2e3b9d1084a8?narHash=sha256-mtpvT%2Bbvzd2HIxa4BYkiRZaArRzLMbYk3JwFKC6Xpkw%3D' (2025-04-05)
  → 'github:yusdacra/nix-cargo-integration/ac4e870a6ea6423347c2a13fc59333251f0a93b0?narHash=sha256-SqT5qH1zEh2CUHpQmZNLqZkZB7bAhV6rb28nZ5tiTz0%3D' (2025-04-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/2bfc080955153be0be56724be6fa5477b4eefabb?narHash=sha256-y7Hg5lwWhEOgflEHRfzSH96BOt26LaYfrYWzZ%2BVoVdg%3D' (2025-04-03)
  → 'github:nixos/nixpkgs/250b695f41e0e2f5afbf15c6b12480de1fe0001b?narHash=sha256-drDyYyUmjeYGiHmwB9eOPTQRjmrq3Yz26knwmMPLZFk%3D' (2025-04-05)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/9d00c6b69408dd40d067603012938d9fbe95cfcd?narHash=sha256-Thah1oU8Vy0gs9bh5QhNcQh1iuQiowMnZPbrkURonZA%3D' (2025-04-06)
  → 'github:oxalica/rust-overlay/0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b?narHash=sha256-u8GHvduU1gCtoFXvTS/wGjH1ouv5S/GRGq6MAT%2BsG/k%3D' (2025-04-07)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
