### PR TITLE
Updating flake inputs Tue Apr  8 05:15:21 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743008896,
-        "narHash": "sha256-mU0WYwrgN8Sus4ktBsSzkvs0++vAKrhNE0A0vWo8AzY=",
+        "lastModified": 1744064663,
+        "narHash": "sha256-iAvwn/x+PsnM2mJS4VvoLNDbwP6Z9kbJorgYciU1+S8=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "7ae2142c8b5a47bed6d403fdd5f5a1215961e10c",
+        "rev": "2bd75af2ebf079b6f57880560b866e38fde7fd0e",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1743979010,
-        "narHash": "sha256-cw6j4Oq4zzwFEhaOgZ69ngdN3KvcT7nafhkfwzBDxNw=",
+        "lastModified": 1744048770,
+        "narHash": "sha256-Zq46FiNkaTemvbvHHZhhE41g/fBIsI8K4QwPobbSa9o=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "b840f902525f02db345508b156fe4585bf877e2b",
+        "rev": "13b64229a01c8dae74177299147156b7ac85094d",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743998782,
-        "narHash": "sha256-gckmtwW/H0jEM1Y8G3wBLfr2nJvwBdjuqnjKNV0lcQY=",
+        "lastModified": 1744038920,
+        "narHash": "sha256-9a4V1wQXS8hXZtc7mRtz0qINkGW+C99aDrmXY6oYBFg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c15ab0ce0dbe64843358a3081b09ed35144dfd65",
+        "rev": "a4d8020820a85b47f842eae76ad083b0ec2a886a",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1744017811,
-        "narHash": "sha256-9o7I4qk0flaFlrO5fBuntJO3XSEWAM9WuoPEA/Y+LXE=",
+        "lastModified": 1744047638,
+        "narHash": "sha256-PWjfCCLhUoBPauCr+KYqMvId8sfTltIZnCROycOpzWg=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "1e3cc16aae6bfae46235857a52cfaa253a90e142",
+        "rev": "50d2f9d269aee8ff9b8f98198c7bacd6fc1aa991",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743920150,
-        "narHash": "sha256-SqT5qH1zEh2CUHpQmZNLqZkZB7bAhV6rb28nZ5tiTz0=",
+        "lastModified": 1744006691,
+        "narHash": "sha256-+kPdaxliIFjlcrt4wwOGxVPbCMYfoJL0KT/uYGRxqWY=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "ac4e870a6ea6423347c2a13fc59333251f0a93b0",
+        "rev": "bf8b32c790e39f45153a58a5a32e85ca70e41272",
         "type": "github"
       },
       "original": {
@@ -591,11 +591,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743814133,
-        "narHash": "sha256-drDyYyUmjeYGiHmwB9eOPTQRjmrq3Yz26knwmMPLZFk=",
+        "lastModified": 1743938762,
+        "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "250b695f41e0e2f5afbf15c6b12480de1fe0001b",
+        "rev": "74a40410369a1c35ee09b8a1abee6f4acbedc059",
         "type": "github"
       },
       "original": {
@@ -770,11 +770,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743993291,
-        "narHash": "sha256-u8GHvduU1gCtoFXvTS/wGjH1ouv5S/GRGq6MAT+sG/k=",
+        "lastModified": 1744079607,
+        "narHash": "sha256-5cog6Qd6w/bINdLO5mOysAHOHey8PwFXk4IWo+y+Czg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b",
+        "rev": "f6b62cc99c25e79a1c17e9fca91dc6b6faebec6c",
         "type": "github"
       },
       "original": {
@@ -813,11 +813,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743910657,
-        "narHash": "sha256-zr2jmWeWyhCD8WmO2aWov2g0WPPuZfcJDKzMJZYGq3Y=",
+        "lastModified": 1744070144,
+        "narHash": "sha256-ZB6q4xnSWm1eIKjpH195NJ7rlOzQ84BWSCoc002gdLI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "523f58a4faff6c67f5f685bed33a7721e984c304",
+        "rev": "04eb34c6c5be9298e0628ef6532acad4fadbfa21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Tue Apr  8 05:15:21 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/2bd75af2ebf079b6f57880560b866e38fde7fd0e' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/80ceeec0dc94ef967c371dcdc56adb280328f591' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/13b64229a01c8dae74177299147156b7ac85094d' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/a4d8020820a85b47f842eae76ad083b0ec2a886a' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/50d2f9d269aee8ff9b8f98198c7bacd6fc1aa991' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/bf8b32c790e39f45153a58a5a32e85ca70e41272' into the Git cache...
unpacking 'github:LnL7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd' into the Git cache...
unpacking 'github:nix-community/nix-index-database/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/04ca471073510af702d75759fd6b3dcb833dfbb2' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215' into the Git cache...
unpacking 'github:nixos/nixpkgs/74a40410369a1c35ee09b8a1abee6f4acbedc059' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/f6b62cc99c25e79a1c17e9fca91dc6b6faebec6c' into the Git cache...
unpacking 'github:Mic92/sops-nix/04eb34c6c5be9298e0628ef6532acad4fadbfa21' into the Git cache...
unpacking 'github:numtide/treefmt-nix/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/7ae2142c8b5a47bed6d403fdd5f5a1215961e10c?narHash=sha256-mU0WYwrgN8Sus4ktBsSzkvs0%2B%2BvAKrhNE0A0vWo8AzY%3D' (2025-03-26)
  → 'github:numtide/blueprint/2bd75af2ebf079b6f57880560b866e38fde7fd0e?narHash=sha256-iAvwn/x%2BPsnM2mJS4VvoLNDbwP6Z9kbJorgYciU1%2BS8%3D' (2025-04-07)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/b840f902525f02db345508b156fe4585bf877e2b?narHash=sha256-cw6j4Oq4zzwFEhaOgZ69ngdN3KvcT7nafhkfwzBDxNw%3D' (2025-04-06)
  → 'github:doomemacs/doomemacs/13b64229a01c8dae74177299147156b7ac85094d?narHash=sha256-Zq46FiNkaTemvbvHHZhhE41g/fBIsI8K4QwPobbSa9o%3D' (2025-04-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c15ab0ce0dbe64843358a3081b09ed35144dfd65?narHash=sha256-gckmtwW/H0jEM1Y8G3wBLfr2nJvwBdjuqnjKNV0lcQY%3D' (2025-04-07)
  → 'github:nix-community/home-manager/a4d8020820a85b47f842eae76ad083b0ec2a886a?narHash=sha256-9a4V1wQXS8hXZtc7mRtz0qINkGW%2BC99aDrmXY6oYBFg%3D' (2025-04-07)
• Updated input 'jjui':
    'github:idursun/jjui/1e3cc16aae6bfae46235857a52cfaa253a90e142?narHash=sha256-9o7I4qk0flaFlrO5fBuntJO3XSEWAM9WuoPEA/Y%2BLXE%3D' (2025-04-07)
  → 'github:idursun/jjui/50d2f9d269aee8ff9b8f98198c7bacd6fc1aa991?narHash=sha256-PWjfCCLhUoBPauCr%2BKYqMvId8sfTltIZnCROycOpzWg%3D' (2025-04-07)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/ac4e870a6ea6423347c2a13fc59333251f0a93b0?narHash=sha256-SqT5qH1zEh2CUHpQmZNLqZkZB7bAhV6rb28nZ5tiTz0%3D' (2025-04-06)
  → 'github:yusdacra/nix-cargo-integration/bf8b32c790e39f45153a58a5a32e85ca70e41272?narHash=sha256-%2BkPdaxliIFjlcrt4wwOGxVPbCMYfoJL0KT/uYGRxqWY%3D' (2025-04-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/250b695f41e0e2f5afbf15c6b12480de1fe0001b?narHash=sha256-drDyYyUmjeYGiHmwB9eOPTQRjmrq3Yz26knwmMPLZFk%3D' (2025-04-05)
  → 'github:nixos/nixpkgs/74a40410369a1c35ee09b8a1abee6f4acbedc059?narHash=sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI%3D' (2025-04-06)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b?narHash=sha256-u8GHvduU1gCtoFXvTS/wGjH1ouv5S/GRGq6MAT%2BsG/k%3D' (2025-04-07)
  → 'github:oxalica/rust-overlay/f6b62cc99c25e79a1c17e9fca91dc6b6faebec6c?narHash=sha256-5cog6Qd6w/bINdLO5mOysAHOHey8PwFXk4IWo%2By%2BCzg%3D' (2025-04-08)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/523f58a4faff6c67f5f685bed33a7721e984c304?narHash=sha256-zr2jmWeWyhCD8WmO2aWov2g0WPPuZfcJDKzMJZYGq3Y%3D' (2025-04-06)
  → 'github:Mic92/sops-nix/04eb34c6c5be9298e0628ef6532acad4fadbfa21?narHash=sha256-ZB6q4xnSWm1eIKjpH195NJ7rlOzQ84BWSCoc002gdLI%3D' (2025-04-07)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
