### PR TITLE
Updating flake inputs Fri Apr 11 05:16:48 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1722017365,
-        "narHash": "sha256-9wYR5NZIgI+qzMDlJrUzevR31fvFQRgfjlYp50Xp3Ts=",
+        "lastModified": 1739520703,
+        "narHash": "sha256-UqR1f9gThWNBCBobWet7T46vTSxkB6dVAdeqNBoF8mc=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "9d024c07ee8c18609b43436bc865abf46636e250",
+        "rev": "ddccfe8aced779f7b54d27bbe7e122ecb1dda33a",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1744237236,
-        "narHash": "sha256-3cMRCnGMKacyo67u4ILfrqGLGrf5jm6gt8IdHdQIux8=",
+        "lastModified": 1744326771,
+        "narHash": "sha256-3N/en5qIy6sTgk+ROCqwk+1GC8RMq2+Dq80Wyff5HzY=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ae2cdd1c9114169d2fbe34ebcd1f77b6a4165488",
+        "rev": "c233aada0b3e8989b4be78f7f8cae540074b832b",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744223888,
-        "narHash": "sha256-reYpe0J1J+wH34JFs7KKp0G5nP7+XSQ5z0ZLFJcfJr8=",
+        "lastModified": 1744343724,
+        "narHash": "sha256-DkiOZlkXbdf6f09pSulJPE0IaaJi1p7sqia/G2kqNKI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79461936709b12e17adb9c91dd02d1c66d577f09",
+        "rev": "f1ffd097e717a8d1b441577b8d23f9d2c96e0657",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1744190885,
-        "narHash": "sha256-ZbAdsdOH1EnPD90A2jJzeVASVqyjEIVBFHbYC1/yASE=",
+        "lastModified": 1744295073,
+        "narHash": "sha256-sdHcM0uqQoFjKnZq3t32zQcUYGSkKljytvJ3YkJ/GAc=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "060838097ce9dbab3143143dd989c9042ec12229",
+        "rev": "1479dfb34d3dd13a61ab5aae9d17fd8540da8ad6",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744179471,
-        "narHash": "sha256-fklm0h/eImrb8bBkuKcxzpC+9sM6pTGlEVcX9MNBmW8=",
+        "lastModified": 1744265869,
+        "narHash": "sha256-8NgUe9cXuS2ocL6rgQyzAs/d4Uo/C5xZLusbbFsUhMg=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "42ddde2ad2611c5b34e7ae88a4d243d674aa0a29",
+        "rev": "1a671a957ac7441e01b5b067cddf104167aa13b3",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743125458,
-        "narHash": "sha256-0z+5AMacL2Eqo92fAd0eCWeKVecWrxPJwd5/BIfcdJ8=",
+        "lastModified": 1744290088,
+        "narHash": "sha256-/X9XVEl0EiyisNbF5srrxXRSVoRqdwExuqyspYqqEjQ=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "394c77f61ac76399290bfc2ef9d47b1fba31b215",
+        "rev": "60b4904a1390ac4c89e93d95f6ed928975e525ed",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744096231,
-        "narHash": "sha256-kUfx3FKU1Etnua3EaKvpeuXs7zoFiAcli1gBwkPvGSs=",
+        "lastModified": 1744157173,
+        "narHash": "sha256-bWSjxDwq7iVePrhmA7tY2dyMWHuNJo8knkO4y+q4ZkY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b2b0718004cc9a5bca610326de0a82e6ea75920b",
+        "rev": "6a39c6e495eefabc935d8ddf66aa45d85b85fa3f",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740555120,
-        "narHash": "sha256-fr3VF1e9hWmaZmAAqcv6QQKV5QId3Y5AYmzn2PyUJSw=",
+        "lastModified": 1744294621,
+        "narHash": "sha256-/5novPf4dOwMCru9e4op+urS6svpLtJhPLhNdbGXpBw=",
         "ref": "refs/heads/master",
-        "rev": "ffc86f8a9687a1a085f955abe058c7f1cb65daa6",
-        "revCount": 2180,
+        "rev": "3dba4fbc91dc7f9cf9b5fd01a0d62262be3f4a6d",
+        "revCount": 2186,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744252416,
-        "narHash": "sha256-Vrs2GxaL0tLi9GCIUrutHgPSr+g7GYCetu7argsNrB4=",
+        "lastModified": 1744338850,
+        "narHash": "sha256-pwMIVmsb8fjjT92n5XFDqCsplcX70qVMMT7NulumPXs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2af83121f9d2c5281796e60e2b048906a84b9fac",
+        "rev": "5e64aecc018e6f775572609e7d7485fdba6985a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Apr 11 05:16:48 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/80ceeec0dc94ef967c371dcdc56adb280328f591' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/c233aada0b3e8989b4be78f7f8cae540074b832b' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/f1ffd097e717a8d1b441577b8d23f9d2c96e0657' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/1479dfb34d3dd13a61ab5aae9d17fd8540da8ad6' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/1a671a957ac7441e01b5b067cddf104167aa13b3' into the Git cache...
unpacking 'github:LnL7/nix-darwin/113883e37d985d26ecb65282766e5719f2539103' into the Git cache...
unpacking 'github:nix-community/nix-index-database/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/d1dd16930e6c9b05d5353e645dcfaee199d44972' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/6a39c6e495eefabc935d8ddf66aa45d85b85fa3f' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/5e64aecc018e6f775572609e7d7485fdba6985a7' into the Git cache...
unpacking 'github:Mic92/sops-nix/69d5a5a4635c27dae5a742f36108beccc506c1ba' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/ae2cdd1c9114169d2fbe34ebcd1f77b6a4165488?narHash=sha256-3cMRCnGMKacyo67u4ILfrqGLGrf5jm6gt8IdHdQIux8%3D' (2025-04-09)
  → 'github:doomemacs/doomemacs/c233aada0b3e8989b4be78f7f8cae540074b832b?narHash=sha256-3N/en5qIy6sTgk%2BROCqwk%2B1GC8RMq2%2BDq80Wyff5HzY%3D' (2025-04-10)
• Updated input 'home-manager':
    'github:nix-community/home-manager/79461936709b12e17adb9c91dd02d1c66d577f09?narHash=sha256-reYpe0J1J%2BwH34JFs7KKp0G5nP7%2BXSQ5z0ZLFJcfJr8%3D' (2025-04-09)
  → 'github:nix-community/home-manager/f1ffd097e717a8d1b441577b8d23f9d2c96e0657?narHash=sha256-DkiOZlkXbdf6f09pSulJPE0IaaJi1p7sqia/G2kqNKI%3D' (2025-04-11)
• Updated input 'jjui':
    'github:idursun/jjui/060838097ce9dbab3143143dd989c9042ec12229?narHash=sha256-ZbAdsdOH1EnPD90A2jJzeVASVqyjEIVBFHbYC1/yASE%3D' (2025-04-09)
  → 'github:idursun/jjui/1479dfb34d3dd13a61ab5aae9d17fd8540da8ad6?narHash=sha256-sdHcM0uqQoFjKnZq3t32zQcUYGSkKljytvJ3YkJ/GAc%3D' (2025-04-10)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/42ddde2ad2611c5b34e7ae88a4d243d674aa0a29?narHash=sha256-fklm0h/eImrb8bBkuKcxzpC%2B9sM6pTGlEVcX9MNBmW8%3D' (2025-04-09)
  → 'github:yusdacra/nix-cargo-integration/1a671a957ac7441e01b5b067cddf104167aa13b3?narHash=sha256-8NgUe9cXuS2ocL6rgQyzAs/d4Uo/C5xZLusbbFsUhMg%3D' (2025-04-10)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/394c77f61ac76399290bfc2ef9d47b1fba31b215?narHash=sha256-0z%2B5AMacL2Eqo92fAd0eCWeKVecWrxPJwd5/BIfcdJ8%3D' (2025-03-28)
  → 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed?narHash=sha256-/X9XVEl0EiyisNbF5srrxXRSVoRqdwExuqyspYqqEjQ%3D' (2025-04-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b2b0718004cc9a5bca610326de0a82e6ea75920b?narHash=sha256-kUfx3FKU1Etnua3EaKvpeuXs7zoFiAcli1gBwkPvGSs%3D' (2025-04-08)
  → 'github:nixos/nixpkgs/6a39c6e495eefabc935d8ddf66aa45d85b85fa3f?narHash=sha256-bWSjxDwq7iVePrhmA7tY2dyMWHuNJo8knkO4y%2Bq4ZkY%3D' (2025-04-09)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=ffc86f8a9687a1a085f955abe058c7f1cb65daa6' (2025-02-26)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=3dba4fbc91dc7f9cf9b5fd01a0d62262be3f4a6d' (2025-04-10)
• Updated input 'radicle/advisory-db':
    'github:rustsec/advisory-db/9d024c07ee8c18609b43436bc865abf46636e250?narHash=sha256-9wYR5NZIgI%2BqzMDlJrUzevR31fvFQRgfjlYp50Xp3Ts%3D' (2024-07-26)
  → 'github:rustsec/advisory-db/ddccfe8aced779f7b54d27bbe7e122ecb1dda33a?narHash=sha256-UqR1f9gThWNBCBobWet7T46vTSxkB6dVAdeqNBoF8mc%3D' (2025-02-14)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/2af83121f9d2c5281796e60e2b048906a84b9fac?narHash=sha256-Vrs2GxaL0tLi9GCIUrutHgPSr%2Bg7GYCetu7argsNrB4%3D' (2025-04-10)
  → 'github:oxalica/rust-overlay/5e64aecc018e6f775572609e7d7485fdba6985a7?narHash=sha256-pwMIVmsb8fjjT92n5XFDqCsplcX70qVMMT7NulumPXs%3D' (2025-04-11)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
