### PR TITLE
Updating flake inputs Sat Apr 12 05:14:20 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1743908961,
-        "narHash": "sha256-e1idZdpnnHWuosI3KsBgAgrhMR05T2oqskXCmNzGPq0=",
+        "lastModified": 1744386647,
+        "narHash": "sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "80ceeec0dc94ef967c371dcdc56adb280328f591",
+        "rev": "d02c1cdd7ec539699aa44e6ff912e15535969803",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1744326771,
-        "narHash": "sha256-3N/en5qIy6sTgk+ROCqwk+1GC8RMq2+Dq80Wyff5HzY=",
+        "lastModified": 1744400981,
+        "narHash": "sha256-8bBhEmytBSPksB04vhcx0XUTW0wES0A5RATcvluTveg=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c233aada0b3e8989b4be78f7f8cae540074b832b",
+        "rev": "c6f749e67c13342007f6aeaa4a81e6fdb00f529f",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744343724,
-        "narHash": "sha256-DkiOZlkXbdf6f09pSulJPE0IaaJi1p7sqia/G2kqNKI=",
+        "lastModified": 1744400600,
+        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f1ffd097e717a8d1b441577b8d23f9d2c96e0657",
+        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744265869,
-        "narHash": "sha256-8NgUe9cXuS2ocL6rgQyzAs/d4Uo/C5xZLusbbFsUhMg=",
+        "lastModified": 1744352257,
+        "narHash": "sha256-vc/pimVF8RQfQJMM+2pssefXrrXelhtAdmkpL+EsCXk=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "1a671a957ac7441e01b5b067cddf104167aa13b3",
+        "rev": "007f9c1e7e1be5984fce24763489c381be9e3127",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744237084,
-        "narHash": "sha256-o4cwSMpY67H1K/DWc+8UMgYp4SS5N2wtbE8jUX881w8=",
+        "lastModified": 1744406060,
+        "narHash": "sha256-4R60vVuvTuY8OMhSveYsGf2rcRK0gvlpGFfa2OI/vY8=",
         "owner": "vic",
         "repo": "nix-versions",
-        "rev": "d1dd16930e6c9b05d5353e645dcfaee199d44972",
+        "rev": "cf79ffa1bd461eb8ff51138504694abd03a356a2",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744157173,
-        "narHash": "sha256-bWSjxDwq7iVePrhmA7tY2dyMWHuNJo8knkO4y+q4ZkY=",
+        "lastModified": 1744316434,
+        "narHash": "sha256-lzFCg/1C39pyY2hMB2gcuHV79ozpOz/Vu15hdjiFOfI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6a39c6e495eefabc935d8ddf66aa45d85b85fa3f",
+        "rev": "d19cf9dfc633816a437204555afeb9e722386b76",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744294621,
-        "narHash": "sha256-/5novPf4dOwMCru9e4op+urS6svpLtJhPLhNdbGXpBw=",
+        "lastModified": 1744367755,
+        "narHash": "sha256-APnLqoxL4oNQFWgxQHxtbYD6OAXLv2ToXxPAEB4MEnE=",
         "ref": "refs/heads/master",
-        "rev": "3dba4fbc91dc7f9cf9b5fd01a0d62262be3f4a6d",
-        "revCount": 2186,
+        "rev": "c847a16e141a57a803b270841d5af38ab56719eb",
+        "revCount": 2189,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744338850,
-        "narHash": "sha256-pwMIVmsb8fjjT92n5XFDqCsplcX70qVMMT7NulumPXs=",
+        "lastModified": 1744425163,
+        "narHash": "sha256-iFcqIbyY25uhtRrQal5vFTxt0q59vDf++nY8du5hof4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5e64aecc018e6f775572609e7d7485fdba6985a7",
+        "rev": "4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Apr 12 05:14:20 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/c6f749e67c13342007f6aeaa4a81e6fdb00f529f' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/b74b22bb6167e8dff083ec6988c98798bf8954d3' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/1479dfb34d3dd13a61ab5aae9d17fd8540da8ad6' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/007f9c1e7e1be5984fce24763489c381be9e3127' into the Git cache...
unpacking 'github:LnL7/nix-darwin/113883e37d985d26ecb65282766e5719f2539103' into the Git cache...
unpacking 'github:nix-community/nix-index-database/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/cf79ffa1bd461eb8ff51138504694abd03a356a2' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/d19cf9dfc633816a437204555afeb9e722386b76' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79' into the Git cache...
unpacking 'github:Mic92/sops-nix/69d5a5a4635c27dae5a742f36108beccc506c1ba' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/80ceeec0dc94ef967c371dcdc56adb280328f591?narHash=sha256-e1idZdpnnHWuosI3KsBgAgrhMR05T2oqskXCmNzGPq0%3D' (2025-04-06)
  → 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803?narHash=sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ%3D' (2025-04-11)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/c233aada0b3e8989b4be78f7f8cae540074b832b?narHash=sha256-3N/en5qIy6sTgk%2BROCqwk%2B1GC8RMq2%2BDq80Wyff5HzY%3D' (2025-04-10)
  → 'github:doomemacs/doomemacs/c6f749e67c13342007f6aeaa4a81e6fdb00f529f?narHash=sha256-8bBhEmytBSPksB04vhcx0XUTW0wES0A5RATcvluTveg%3D' (2025-04-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f1ffd097e717a8d1b441577b8d23f9d2c96e0657?narHash=sha256-DkiOZlkXbdf6f09pSulJPE0IaaJi1p7sqia/G2kqNKI%3D' (2025-04-11)
  → 'github:nix-community/home-manager/b74b22bb6167e8dff083ec6988c98798bf8954d3?narHash=sha256-qYhUgA98mhq1QK13r9qVY%2BsG1ri6FBgyp%2BGApX6wS20%3D' (2025-04-11)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/1a671a957ac7441e01b5b067cddf104167aa13b3?narHash=sha256-8NgUe9cXuS2ocL6rgQyzAs/d4Uo/C5xZLusbbFsUhMg%3D' (2025-04-10)
  → 'github:yusdacra/nix-cargo-integration/007f9c1e7e1be5984fce24763489c381be9e3127?narHash=sha256-vc/pimVF8RQfQJMM%2B2pssefXrrXelhtAdmkpL%2BEsCXk%3D' (2025-04-11)
• Updated input 'nix-versions':
    'github:vic/nix-versions/d1dd16930e6c9b05d5353e645dcfaee199d44972?narHash=sha256-o4cwSMpY67H1K/DWc%2B8UMgYp4SS5N2wtbE8jUX881w8%3D' (2025-04-09)
  → 'github:vic/nix-versions/cf79ffa1bd461eb8ff51138504694abd03a356a2?narHash=sha256-4R60vVuvTuY8OMhSveYsGf2rcRK0gvlpGFfa2OI/vY8%3D' (2025-04-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6a39c6e495eefabc935d8ddf66aa45d85b85fa3f?narHash=sha256-bWSjxDwq7iVePrhmA7tY2dyMWHuNJo8knkO4y%2Bq4ZkY%3D' (2025-04-09)
  → 'github:nixos/nixpkgs/d19cf9dfc633816a437204555afeb9e722386b76?narHash=sha256-lzFCg/1C39pyY2hMB2gcuHV79ozpOz/Vu15hdjiFOfI%3D' (2025-04-10)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=3dba4fbc91dc7f9cf9b5fd01a0d62262be3f4a6d' (2025-04-10)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=c847a16e141a57a803b270841d5af38ab56719eb' (2025-04-11)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/5e64aecc018e6f775572609e7d7485fdba6985a7?narHash=sha256-pwMIVmsb8fjjT92n5XFDqCsplcX70qVMMT7NulumPXs%3D' (2025-04-11)
  → 'github:oxalica/rust-overlay/4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79?narHash=sha256-iFcqIbyY25uhtRrQal5vFTxt0q59vDf%2B%2BnY8du5hof4%3D' (2025-04-12)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
