### PR TITLE
Updating flake inputs Sun Apr 13 05:20:40 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744400600,
-        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
+        "lastModified": 1744498625,
+        "narHash": "sha256-pL52uCt9CUoTTmysGG91c2FeU7XUvpB7Cep6yon2vDk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
+        "rev": "db56335ca8942d86f2200664acdbd5b9212b26ad",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1744295073,
-        "narHash": "sha256-sdHcM0uqQoFjKnZq3t32zQcUYGSkKljytvJ3YkJ/GAc=",
+        "lastModified": 1744488747,
+        "narHash": "sha256-1pY5BmcVsOaWgpCtJwNXxOYcPCW25FOuD/wvNj9EMXI=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "1479dfb34d3dd13a61ab5aae9d17fd8540da8ad6",
+        "rev": "d8ad6ee47aa9605e1e2665ca029391bb207177a8",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744352257,
-        "narHash": "sha256-vc/pimVF8RQfQJMM+2pssefXrrXelhtAdmkpL+EsCXk=",
+        "lastModified": 1744438518,
+        "narHash": "sha256-LI3e9jx0VIXtralWd9Cya/Z6cLwVy7S5aBQHa3Rprlk=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "007f9c1e7e1be5984fce24763489c381be9e3127",
+        "rev": "c48a97208bd82de8dbe3df11aedad73c1f5147db",
         "type": "github"
       },
       "original": {
@@ -438,11 +438,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744224272,
-        "narHash": "sha256-cqePj5nuC7flJWNncaVAFq1YZncU0PSyO0DEqGn+vYc=",
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "113883e37d985d26ecb65282766e5719f2539103",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
         "type": "github"
       },
       "original": {
@@ -458,11 +458,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743911143,
-        "narHash": "sha256-4j4JPwr0TXHH4ZyorXN5yIcmqIQr0WYacsuPA4ktONo=",
+        "lastModified": 1744518957,
+        "narHash": "sha256-RLBSWQfTL0v+7uyskC5kP6slLK1jvIuhaAh8QvB75m4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "a36f6a7148aec2c77d78e4466215cceb2f5f4bfb",
+        "rev": "4fc9ea78c962904f4ea11046f3db37c62e8a02fd",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744406060,
-        "narHash": "sha256-4R60vVuvTuY8OMhSveYsGf2rcRK0gvlpGFfa2OI/vY8=",
+        "lastModified": 1744513513,
+        "narHash": "sha256-ukDfyA5lPwKr6WO0Z2fqN4TsRkAejBAtR4arFYnyASY=",
         "owner": "vic",
         "repo": "nix-versions",
-        "rev": "cf79ffa1bd461eb8ff51138504694abd03a356a2",
+        "rev": "ef2fadc629f9d8a3ae22e435d81833c86b382d9f",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744316434,
-        "narHash": "sha256-lzFCg/1C39pyY2hMB2gcuHV79ozpOz/Vu15hdjiFOfI=",
+        "lastModified": 1744502386,
+        "narHash": "sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9+a/ONO8qNBYJgM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d19cf9dfc633816a437204555afeb9e722386b76",
+        "rev": "f6db44a8daa59c40ae41ba6e5823ec77fe0d2124",
         "type": "github"
       },
       "original": {
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744425163,
-        "narHash": "sha256-iFcqIbyY25uhtRrQal5vFTxt0q59vDf++nY8du5hof4=",
+        "lastModified": 1744513456,
+        "narHash": "sha256-NLVluTmK8d01Iz+WyarQhwFcXpHEwU7m5hH3YQQFJS0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79",
+        "rev": "730fd8e82799219754418483fabe1844262fd1e2",
         "type": "github"
       },
       "original": {
@@ -807,11 +807,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744103455,
-        "narHash": "sha256-SR6+qjkPjGQG+8eM4dCcVtss8r9bre/LAxFMPJpaZeU=",
+        "lastModified": 1744518500,
+        "narHash": "sha256-lv52pnfiRGp5+xkZEgWr56DWiRgkMFXpiGba3eJ3krE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "69d5a5a4635c27dae5a742f36108beccc506c1ba",
+        "rev": "7e147a1ae90f0d4a374938cdc3df3cdaecb9d388",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sun Apr 13 05:20:40 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/c6f749e67c13342007f6aeaa4a81e6fdb00f529f' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/db56335ca8942d86f2200664acdbd5b9212b26ad' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/d8ad6ee47aa9605e1e2665ca029391bb207177a8' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/c48a97208bd82de8dbe3df11aedad73c1f5147db' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/f6db44a8daa59c40ae41ba6e5823ec77fe0d2124' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/730fd8e82799219754418483fabe1844262fd1e2' into the Git cache...
unpacking 'github:Mic92/sops-nix/7e147a1ae90f0d4a374938cdc3df3cdaecb9d388' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/b74b22bb6167e8dff083ec6988c98798bf8954d3?narHash=sha256-qYhUgA98mhq1QK13r9qVY%2BsG1ri6FBgyp%2BGApX6wS20%3D' (2025-04-11)
  → 'github:nix-community/home-manager/db56335ca8942d86f2200664acdbd5b9212b26ad?narHash=sha256-pL52uCt9CUoTTmysGG91c2FeU7XUvpB7Cep6yon2vDk%3D' (2025-04-12)
• Updated input 'jjui':
    'github:idursun/jjui/1479dfb34d3dd13a61ab5aae9d17fd8540da8ad6?narHash=sha256-sdHcM0uqQoFjKnZq3t32zQcUYGSkKljytvJ3YkJ/GAc%3D' (2025-04-10)
  → 'github:idursun/jjui/d8ad6ee47aa9605e1e2665ca029391bb207177a8?narHash=sha256-1pY5BmcVsOaWgpCtJwNXxOYcPCW25FOuD/wvNj9EMXI%3D' (2025-04-12)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/007f9c1e7e1be5984fce24763489c381be9e3127?narHash=sha256-vc/pimVF8RQfQJMM%2B2pssefXrrXelhtAdmkpL%2BEsCXk%3D' (2025-04-11)
  → 'github:yusdacra/nix-cargo-integration/c48a97208bd82de8dbe3df11aedad73c1f5147db?narHash=sha256-LI3e9jx0VIXtralWd9Cya/Z6cLwVy7S5aBQHa3Rprlk%3D' (2025-04-12)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/113883e37d985d26ecb65282766e5719f2539103?narHash=sha256-cqePj5nuC7flJWNncaVAFq1YZncU0PSyO0DEqGn%2BvYc%3D' (2025-04-09)
  → 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b?narHash=sha256-dyN%2BteG9G82G%2Bm%2BPX/aSAagkC%2BvUv0SgUw3XkPhQodQ%3D' (2025-04-12)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb?narHash=sha256-4j4JPwr0TXHH4ZyorXN5yIcmqIQr0WYacsuPA4ktONo%3D' (2025-04-06)
  → 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd?narHash=sha256-RLBSWQfTL0v%2B7uyskC5kP6slLK1jvIuhaAh8QvB75m4%3D' (2025-04-13)
• Updated input 'nix-versions':
    'github:vic/nix-versions/cf79ffa1bd461eb8ff51138504694abd03a356a2?narHash=sha256-4R60vVuvTuY8OMhSveYsGf2rcRK0gvlpGFfa2OI/vY8%3D' (2025-04-11)
  → 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f?narHash=sha256-ukDfyA5lPwKr6WO0Z2fqN4TsRkAejBAtR4arFYnyASY%3D' (2025-04-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d19cf9dfc633816a437204555afeb9e722386b76?narHash=sha256-lzFCg/1C39pyY2hMB2gcuHV79ozpOz/Vu15hdjiFOfI%3D' (2025-04-10)
  → 'github:nixos/nixpkgs/f6db44a8daa59c40ae41ba6e5823ec77fe0d2124?narHash=sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9%2Ba/ONO8qNBYJgM%3D' (2025-04-12)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79?narHash=sha256-iFcqIbyY25uhtRrQal5vFTxt0q59vDf%2B%2BnY8du5hof4%3D' (2025-04-12)
  → 'github:oxalica/rust-overlay/730fd8e82799219754418483fabe1844262fd1e2?narHash=sha256-NLVluTmK8d01Iz%2BWyarQhwFcXpHEwU7m5hH3YQQFJS0%3D' (2025-04-13)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/69d5a5a4635c27dae5a742f36108beccc506c1ba?narHash=sha256-SR6%2BqjkPjGQG%2B8eM4dCcVtss8r9bre/LAxFMPJpaZeU%3D' (2025-04-08)
  → 'github:Mic92/sops-nix/7e147a1ae90f0d4a374938cdc3df3cdaecb9d388?narHash=sha256-lv52pnfiRGp5%2BxkZEgWr56DWiRgkMFXpiGba3eJ3krE%3D' (2025-04-13)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
