### PR TITLE
Updating flake inputs Mon Apr 14 05:16:39 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744498625,
-        "narHash": "sha256-pL52uCt9CUoTTmysGG91c2FeU7XUvpB7Cep6yon2vDk=",
+        "lastModified": 1744600951,
+        "narHash": "sha256-LNAAfQTDXSwtYYlh/v/tMwnCqeQAEHlBC9PgyQK5b/Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db56335ca8942d86f2200664acdbd5b9212b26ad",
+        "rev": "e980d0e0e216f527ea73cfd12c7b019eceffa7f1",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1744488747,
-        "narHash": "sha256-1pY5BmcVsOaWgpCtJwNXxOYcPCW25FOuD/wvNj9EMXI=",
+        "lastModified": 1744582520,
+        "narHash": "sha256-FsCbMnkwxnKjTXrcDgWhb2Gq7Q7QA776th4Kdg3Ctms=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "d8ad6ee47aa9605e1e2665ca029391bb207177a8",
+        "rev": "4344974f62e9ce29c444c1cea16b4689cf1a6a0a",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744438518,
-        "narHash": "sha256-LI3e9jx0VIXtralWd9Cya/Z6cLwVy7S5aBQHa3Rprlk=",
+        "lastModified": 1744524958,
+        "narHash": "sha256-XTr7KJJom6BwAgbTZLrRtrCey+tnbuWCoAWbhyiBvfk=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "c48a97208bd82de8dbe3df11aedad73c1f5147db",
+        "rev": "4b45985506f3df060959b50620dded35c3508be5",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744502386,
-        "narHash": "sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9+a/ONO8qNBYJgM=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f6db44a8daa59c40ae41ba6e5823ec77fe0d2124",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -617,11 +617,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744513456,
-        "narHash": "sha256-NLVluTmK8d01Iz+WyarQhwFcXpHEwU7m5hH3YQQFJS0=",
+        "lastModified": 1744599145,
+        "narHash": "sha256-yzaDPkJwZdUtRj/dzdOeB74yryWzpngYaD7BedqFKk8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "730fd8e82799219754418483fabe1844262fd1e2",
+        "rev": "fd6795d3d28f956de01a0458b6fa7baae5c793b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Mon Apr 14 05:16:39 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/c6f749e67c13342007f6aeaa4a81e6fdb00f529f' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/e980d0e0e216f527ea73cfd12c7b019eceffa7f1' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/4344974f62e9ce29c444c1cea16b4689cf1a6a0a' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/4b45985506f3df060959b50620dded35c3508be5' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/fd6795d3d28f956de01a0458b6fa7baae5c793b4' into the Git cache...
unpacking 'github:Mic92/sops-nix/7e147a1ae90f0d4a374938cdc3df3cdaecb9d388' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/db56335ca8942d86f2200664acdbd5b9212b26ad?narHash=sha256-pL52uCt9CUoTTmysGG91c2FeU7XUvpB7Cep6yon2vDk%3D' (2025-04-12)
  → 'github:nix-community/home-manager/e980d0e0e216f527ea73cfd12c7b019eceffa7f1?narHash=sha256-LNAAfQTDXSwtYYlh/v/tMwnCqeQAEHlBC9PgyQK5b/Q%3D' (2025-04-14)
• Updated input 'jjui':
    'github:idursun/jjui/d8ad6ee47aa9605e1e2665ca029391bb207177a8?narHash=sha256-1pY5BmcVsOaWgpCtJwNXxOYcPCW25FOuD/wvNj9EMXI%3D' (2025-04-12)
  → 'github:idursun/jjui/4344974f62e9ce29c444c1cea16b4689cf1a6a0a?narHash=sha256-FsCbMnkwxnKjTXrcDgWhb2Gq7Q7QA776th4Kdg3Ctms%3D' (2025-04-13)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/c48a97208bd82de8dbe3df11aedad73c1f5147db?narHash=sha256-LI3e9jx0VIXtralWd9Cya/Z6cLwVy7S5aBQHa3Rprlk%3D' (2025-04-12)
  → 'github:yusdacra/nix-cargo-integration/4b45985506f3df060959b50620dded35c3508be5?narHash=sha256-XTr7KJJom6BwAgbTZLrRtrCey%2BtnbuWCoAWbhyiBvfk%3D' (2025-04-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f6db44a8daa59c40ae41ba6e5823ec77fe0d2124?narHash=sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9%2Ba/ONO8qNBYJgM%3D' (2025-04-12)
  → 'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11?narHash=sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38%3D' (2025-04-13)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/730fd8e82799219754418483fabe1844262fd1e2?narHash=sha256-NLVluTmK8d01Iz%2BWyarQhwFcXpHEwU7m5hH3YQQFJS0%3D' (2025-04-13)
  → 'github:oxalica/rust-overlay/fd6795d3d28f956de01a0458b6fa7baae5c793b4?narHash=sha256-yzaDPkJwZdUtRj/dzdOeB74yryWzpngYaD7BedqFKk8%3D' (2025-04-14)
• Updated input 'rust-overlay/nixpkgs':
    'github:NixOS/nixpkgs/4bc9c909d9ac828a039f288cf872d16d38185db8?narHash=sha256-nIYdTAiKIGnFNugbomgBJR%2BXv5F1ZQU%2BHfaBqJKroC0%3D' (2025-01-08)
  → 'github:NixOS/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11?narHash=sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38%3D' (2025-04-13)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
