### PR TITLE
Updating flake inputs Tue Apr 15 05:17:27 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744122991,
-        "narHash": "sha256-Mk7dW932hmuvtSzyJJgjqF8/7YgDgV0nc3Ju4QtIzXs=",
+        "lastModified": 1744632722,
+        "narHash": "sha256-0chvqUV1Kzf8BMQ7MsH3CeicJEb2HeCpwliS77FGyfc=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "ce2b3370b6915bc457b669e53d04f0231b66b60f",
+        "rev": "49bbd5d072b577072f4a1d07d4b0621ecce768af",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1744400981,
-        "narHash": "sha256-8bBhEmytBSPksB04vhcx0XUTW0wES0A5RATcvluTveg=",
+        "lastModified": 1744691995,
+        "narHash": "sha256-Cz4zw/vV81uTOyNNmI5XE5kTQNHligypp6nDCenYHD8=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c6f749e67c13342007f6aeaa4a81e6fdb00f529f",
+        "rev": "ad0eb9d5a2259a67084ea855eb7ab7125376ff6b",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744600951,
-        "narHash": "sha256-LNAAfQTDXSwtYYlh/v/tMwnCqeQAEHlBC9PgyQK5b/Q=",
+        "lastModified": 1744663884,
+        "narHash": "sha256-a6QGaZMDM1miK8VWzAITsEPOdmLk+xTPyJSTjVs3WhI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e980d0e0e216f527ea73cfd12c7b019eceffa7f1",
+        "rev": "d5cdf55bd9f19a3debd55b6cb5d38f7831426265",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744524958,
-        "narHash": "sha256-XTr7KJJom6BwAgbTZLrRtrCey+tnbuWCoAWbhyiBvfk=",
+        "lastModified": 1744611520,
+        "narHash": "sha256-NSLQtQ4JxFJNqwsHMzob2ydPKQ15J/AIxNWEIM4FMnM=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "4b45985506f3df060959b50620dded35c3508be5",
+        "rev": "39777084550077027e883ee045ce35de5a9fb019",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744367755,
-        "narHash": "sha256-APnLqoxL4oNQFWgxQHxtbYD6OAXLv2ToXxPAEB4MEnE=",
+        "lastModified": 1744619832,
+        "narHash": "sha256-pLt9fSM9NQ0pDHwkW2lTP3Ef8o0X8BbSmAUJLjMA+aE=",
         "ref": "refs/heads/master",
-        "rev": "c847a16e141a57a803b270841d5af38ab56719eb",
-        "revCount": 2189,
+        "rev": "a5665412f67dd45b6557e83db305a0774a83c224",
+        "revCount": 2191,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744599145,
-        "narHash": "sha256-yzaDPkJwZdUtRj/dzdOeB74yryWzpngYaD7BedqFKk8=",
+        "lastModified": 1744684506,
+        "narHash": "sha256-pDPDMT1rdkTWi8MIoZ67gT3L817R7P0Jo+PP+BrnyJI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fd6795d3d28f956de01a0458b6fa7baae5c793b4",
+        "rev": "47beae969336c05e892e1e4a9dbaac9593de34ab",
         "type": "github"
       },
       "original": {
@@ -807,11 +807,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744518500,
-        "narHash": "sha256-lv52pnfiRGp5+xkZEgWr56DWiRgkMFXpiGba3eJ3krE=",
+        "lastModified": 1744669848,
+        "narHash": "sha256-pXyanHLUzLNd3MX9vsWG+6Z2hTU8niyphWstYEP3/GU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "7e147a1ae90f0d4a374938cdc3df3cdaecb9d388",
+        "rev": "61154300d945f0b147b30d24ddcafa159148026a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Tue Apr 15 05:17:27 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:numtide/blueprint/49bbd5d072b577072f4a1d07d4b0621ecce768af' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ad0eb9d5a2259a67084ea855eb7ab7125376ff6b' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/d5cdf55bd9f19a3debd55b6cb5d38f7831426265' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/4344974f62e9ce29c444c1cea16b4689cf1a6a0a' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/39777084550077027e883ee045ce35de5a9fb019' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/47beae969336c05e892e1e4a9dbaac9593de34ab' into the Git cache...
unpacking 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'blueprint':
    'github:numtide/blueprint/ce2b3370b6915bc457b669e53d04f0231b66b60f?narHash=sha256-Mk7dW932hmuvtSzyJJgjqF8/7YgDgV0nc3Ju4QtIzXs%3D' (2025-04-08)
  → 'github:numtide/blueprint/49bbd5d072b577072f4a1d07d4b0621ecce768af?narHash=sha256-0chvqUV1Kzf8BMQ7MsH3CeicJEb2HeCpwliS77FGyfc%3D' (2025-04-14)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/c6f749e67c13342007f6aeaa4a81e6fdb00f529f?narHash=sha256-8bBhEmytBSPksB04vhcx0XUTW0wES0A5RATcvluTveg%3D' (2025-04-11)
  → 'github:doomemacs/doomemacs/ad0eb9d5a2259a67084ea855eb7ab7125376ff6b?narHash=sha256-Cz4zw/vV81uTOyNNmI5XE5kTQNHligypp6nDCenYHD8%3D' (2025-04-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e980d0e0e216f527ea73cfd12c7b019eceffa7f1?narHash=sha256-LNAAfQTDXSwtYYlh/v/tMwnCqeQAEHlBC9PgyQK5b/Q%3D' (2025-04-14)
  → 'github:nix-community/home-manager/d5cdf55bd9f19a3debd55b6cb5d38f7831426265?narHash=sha256-a6QGaZMDM1miK8VWzAITsEPOdmLk%2BxTPyJSTjVs3WhI%3D' (2025-04-14)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/4b45985506f3df060959b50620dded35c3508be5?narHash=sha256-XTr7KJJom6BwAgbTZLrRtrCey%2BtnbuWCoAWbhyiBvfk%3D' (2025-04-13)
  → 'github:yusdacra/nix-cargo-integration/39777084550077027e883ee045ce35de5a9fb019?narHash=sha256-NSLQtQ4JxFJNqwsHMzob2ydPKQ15J/AIxNWEIM4FMnM%3D' (2025-04-14)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=c847a16e141a57a803b270841d5af38ab56719eb' (2025-04-11)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=a5665412f67dd45b6557e83db305a0774a83c224' (2025-04-14)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/fd6795d3d28f956de01a0458b6fa7baae5c793b4?narHash=sha256-yzaDPkJwZdUtRj/dzdOeB74yryWzpngYaD7BedqFKk8%3D' (2025-04-14)
  → 'github:oxalica/rust-overlay/47beae969336c05e892e1e4a9dbaac9593de34ab?narHash=sha256-pDPDMT1rdkTWi8MIoZ67gT3L817R7P0Jo%2BPP%2BBrnyJI%3D' (2025-04-15)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/7e147a1ae90f0d4a374938cdc3df3cdaecb9d388?narHash=sha256-lv52pnfiRGp5%2BxkZEgWr56DWiRgkMFXpiGba3eJ3krE%3D' (2025-04-13)
  → 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a?narHash=sha256-pXyanHLUzLNd3MX9vsWG%2B6Z2hTU8niyphWstYEP3/GU%3D' (2025-04-14)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
