### PR TITLE
Updating flake inputs Wed Apr 16 05:15:45 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1744691995,
-        "narHash": "sha256-Cz4zw/vV81uTOyNNmI5XE5kTQNHligypp6nDCenYHD8=",
+        "lastModified": 1744758525,
+        "narHash": "sha256-DDEVz/3zm//4CieuYYvKHvnDNccOMcApV1vYrWXIgGI=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ad0eb9d5a2259a67084ea855eb7ab7125376ff6b",
+        "rev": "009a285c0a63c305d0aa89f46122b7f98a57e897",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744663884,
-        "narHash": "sha256-a6QGaZMDM1miK8VWzAITsEPOdmLk+xTPyJSTjVs3WhI=",
+        "lastModified": 1744735751,
+        "narHash": "sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5cdf55bd9f19a3debd55b6cb5d38f7831426265",
+        "rev": "db7738e67a101ad945abbcb447e1310147afaf1b",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1744582520,
-        "narHash": "sha256-FsCbMnkwxnKjTXrcDgWhb2Gq7Q7QA776th4Kdg3Ctms=",
+        "lastModified": 1744743183,
+        "narHash": "sha256-EdVm5YsRQBQHqtjo980avhcE5U4bN/QwpVtbDU8kR1A=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "4344974f62e9ce29c444c1cea16b4689cf1a6a0a",
+        "rev": "35444a924b0279dd350eb4a2bcd46ea797529101",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744611520,
-        "narHash": "sha256-NSLQtQ4JxFJNqwsHMzob2ydPKQ15J/AIxNWEIM4FMnM=",
+        "lastModified": 1744697871,
+        "narHash": "sha256-LD1g3kiiAJ7FRSaxJTlBvQC1g46KC1hwbfbKKqpoQis=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "39777084550077027e883ee045ce35de5a9fb019",
+        "rev": "661ba3f41bce9f1fba6571f89ddadf9dc76cada6",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744619832,
-        "narHash": "sha256-pLt9fSM9NQ0pDHwkW2lTP3Ef8o0X8BbSmAUJLjMA+aE=",
+        "lastModified": 1744713755,
+        "narHash": "sha256-KKWhDOlTEMebAVug2YbzHYV0BkRB9PBCIbFrbVpRMRU=",
         "ref": "refs/heads/master",
-        "rev": "a5665412f67dd45b6557e83db305a0774a83c224",
-        "revCount": 2191,
+        "rev": "9abedf449b6720ab7c156ee3c4c40ad4d0165423",
+        "revCount": 2193,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744684506,
-        "narHash": "sha256-pDPDMT1rdkTWi8MIoZ67gT3L817R7P0Jo+PP+BrnyJI=",
+        "lastModified": 1744770893,
+        "narHash": "sha256-RMyTyFHN3w8zwfpgvcfRHQ4vX4zTqhuZbif/MXROtx8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47beae969336c05e892e1e4a9dbaac9593de34ab",
+        "rev": "1633514603fc0ed15ea0aef7327e26736ec003c0",
         "type": "github"
       },
       "original": {
@@ -842,11 +842,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743748085,
-        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
+        "lastModified": 1744707583,
+        "narHash": "sha256-IPFcShGro/UUp8BmwMBkq+6KscPlWQevZi9qqIwVUWg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
+        "rev": "49d05555ccdd2592300099d6a657cc33571f4fe0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Apr 16 05:15:45 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/009a285c0a63c305d0aa89f46122b7f98a57e897' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/db7738e67a101ad945abbcb447e1310147afaf1b' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/35444a924b0279dd350eb4a2bcd46ea797529101' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/661ba3f41bce9f1fba6571f89ddadf9dc76cada6' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/1633514603fc0ed15ea0aef7327e26736ec003c0' into the Git cache...
unpacking 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' into the Git cache...
unpacking 'github:numtide/treefmt-nix/49d05555ccdd2592300099d6a657cc33571f4fe0' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/ad0eb9d5a2259a67084ea855eb7ab7125376ff6b?narHash=sha256-Cz4zw/vV81uTOyNNmI5XE5kTQNHligypp6nDCenYHD8%3D' (2025-04-15)
  → 'github:doomemacs/doomemacs/009a285c0a63c305d0aa89f46122b7f98a57e897?narHash=sha256-DDEVz/3zm//4CieuYYvKHvnDNccOMcApV1vYrWXIgGI%3D' (2025-04-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d5cdf55bd9f19a3debd55b6cb5d38f7831426265?narHash=sha256-a6QGaZMDM1miK8VWzAITsEPOdmLk%2BxTPyJSTjVs3WhI%3D' (2025-04-14)
  → 'github:nix-community/home-manager/db7738e67a101ad945abbcb447e1310147afaf1b?narHash=sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY%3D' (2025-04-15)
• Updated input 'jjui':
    'github:idursun/jjui/4344974f62e9ce29c444c1cea16b4689cf1a6a0a?narHash=sha256-FsCbMnkwxnKjTXrcDgWhb2Gq7Q7QA776th4Kdg3Ctms%3D' (2025-04-13)
  → 'github:idursun/jjui/35444a924b0279dd350eb4a2bcd46ea797529101?narHash=sha256-EdVm5YsRQBQHqtjo980avhcE5U4bN/QwpVtbDU8kR1A%3D' (2025-04-15)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/39777084550077027e883ee045ce35de5a9fb019?narHash=sha256-NSLQtQ4JxFJNqwsHMzob2ydPKQ15J/AIxNWEIM4FMnM%3D' (2025-04-14)
  → 'github:yusdacra/nix-cargo-integration/661ba3f41bce9f1fba6571f89ddadf9dc76cada6?narHash=sha256-LD1g3kiiAJ7FRSaxJTlBvQC1g46KC1hwbfbKKqpoQis%3D' (2025-04-15)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=a5665412f67dd45b6557e83db305a0774a83c224' (2025-04-14)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=9abedf449b6720ab7c156ee3c4c40ad4d0165423' (2025-04-15)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/47beae969336c05e892e1e4a9dbaac9593de34ab?narHash=sha256-pDPDMT1rdkTWi8MIoZ67gT3L817R7P0Jo%2BPP%2BBrnyJI%3D' (2025-04-15)
  → 'github:oxalica/rust-overlay/1633514603fc0ed15ea0aef7327e26736ec003c0?narHash=sha256-RMyTyFHN3w8zwfpgvcfRHQ4vX4zTqhuZbif/MXROtx8%3D' (2025-04-16)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d?narHash=sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660%2BgbUU3cE%3D' (2025-04-04)
  → 'github:numtide/treefmt-nix/49d05555ccdd2592300099d6a657cc33571f4fe0?narHash=sha256-IPFcShGro/UUp8BmwMBkq%2B6KscPlWQevZi9qqIwVUWg%3D' (2025-04-15)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
