### PR TITLE
Updating flake inputs Thu Apr 17 05:15:38 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1744758525,
-        "narHash": "sha256-DDEVz/3zm//4CieuYYvKHvnDNccOMcApV1vYrWXIgGI=",
+        "lastModified": 1744859264,
+        "narHash": "sha256-yCT9DUQzJnr4KNZjrGnsZSJstsHGkY3WIZ9WqdJ7jRo=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "009a285c0a63c305d0aa89f46122b7f98a57e897",
+        "rev": "baf680f9c8dc699f458888583423789fd41f8c19",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744735751,
-        "narHash": "sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY=",
+        "lastModified": 1744833442,
+        "narHash": "sha256-BBMWW2m64Grcc5FlXz74+vdkUyCJOfUGnl+VcS/4x44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db7738e67a101ad945abbcb447e1310147afaf1b",
+        "rev": "c6b75d69b6994ba68ec281bd36faebcc56097800",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1744743183,
-        "narHash": "sha256-EdVm5YsRQBQHqtjo980avhcE5U4bN/QwpVtbDU8kR1A=",
+        "lastModified": 1744841719,
+        "narHash": "sha256-wsfGB84kEK1l5OyyN6dGEUD4JXfpcrEOdFyTvuspscs=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "35444a924b0279dd350eb4a2bcd46ea797529101",
+        "rev": "990e6ef31bc2ad3b713917c3acd42140ee2d1216",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744697871,
-        "narHash": "sha256-LD1g3kiiAJ7FRSaxJTlBvQC1g46KC1hwbfbKKqpoQis=",
+        "lastModified": 1744784266,
+        "narHash": "sha256-DgvMekzi/+QCVwKyvLdxabgAyxpi+iANADyoR9yTpIk=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "661ba3f41bce9f1fba6571f89ddadf9dc76cada6",
+        "rev": "2b6ba726da45d80205a5d636d5abb137be701ed8",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744713755,
-        "narHash": "sha256-KKWhDOlTEMebAVug2YbzHYV0BkRB9PBCIbFrbVpRMRU=",
+        "lastModified": 1744826984,
+        "narHash": "sha256-oVRn+J9I6c6vyokjkwh8Bty+cqADFpQnmMg/A6hK0wQ=",
         "ref": "refs/heads/master",
-        "rev": "9abedf449b6720ab7c156ee3c4c40ad4d0165423",
-        "revCount": 2193,
+        "rev": "47c785b9160c31ab360e15c7b2f849e5225ecc66",
+        "revCount": 2199,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744770893,
-        "narHash": "sha256-RMyTyFHN3w8zwfpgvcfRHQ4vX4zTqhuZbif/MXROtx8=",
+        "lastModified": 1744857263,
+        "narHash": "sha256-M4X/CnquHozzgwDk+CbFb8Sb4rSGJttfNOKcpRwziis=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1633514603fc0ed15ea0aef7327e26736ec003c0",
+        "rev": "9f3d63d569536cd661a4adcf697e32eb08d61e31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Apr 17 05:15:38 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/baf680f9c8dc699f458888583423789fd41f8c19' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/c6b75d69b6994ba68ec281bd36faebcc56097800' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/990e6ef31bc2ad3b713917c3acd42140ee2d1216' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/2b6ba726da45d80205a5d636d5abb137be701ed8' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/9f3d63d569536cd661a4adcf697e32eb08d61e31' into the Git cache...
unpacking 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/009a285c0a63c305d0aa89f46122b7f98a57e897?narHash=sha256-DDEVz/3zm//4CieuYYvKHvnDNccOMcApV1vYrWXIgGI%3D' (2025-04-15)
  → 'github:doomemacs/doomemacs/baf680f9c8dc699f458888583423789fd41f8c19?narHash=sha256-yCT9DUQzJnr4KNZjrGnsZSJstsHGkY3WIZ9WqdJ7jRo%3D' (2025-04-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/db7738e67a101ad945abbcb447e1310147afaf1b?narHash=sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY%3D' (2025-04-15)
  → 'github:nix-community/home-manager/c6b75d69b6994ba68ec281bd36faebcc56097800?narHash=sha256-BBMWW2m64Grcc5FlXz74%2BvdkUyCJOfUGnl%2BVcS/4x44%3D' (2025-04-16)
• Updated input 'jjui':
    'github:idursun/jjui/35444a924b0279dd350eb4a2bcd46ea797529101?narHash=sha256-EdVm5YsRQBQHqtjo980avhcE5U4bN/QwpVtbDU8kR1A%3D' (2025-04-15)
  → 'github:idursun/jjui/990e6ef31bc2ad3b713917c3acd42140ee2d1216?narHash=sha256-wsfGB84kEK1l5OyyN6dGEUD4JXfpcrEOdFyTvuspscs%3D' (2025-04-16)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/661ba3f41bce9f1fba6571f89ddadf9dc76cada6?narHash=sha256-LD1g3kiiAJ7FRSaxJTlBvQC1g46KC1hwbfbKKqpoQis%3D' (2025-04-15)
  → 'github:yusdacra/nix-cargo-integration/2b6ba726da45d80205a5d636d5abb137be701ed8?narHash=sha256-DgvMekzi/%2BQCVwKyvLdxabgAyxpi%2BiANADyoR9yTpIk%3D' (2025-04-16)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=9abedf449b6720ab7c156ee3c4c40ad4d0165423' (2025-04-15)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=47c785b9160c31ab360e15c7b2f849e5225ecc66' (2025-04-16)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/1633514603fc0ed15ea0aef7327e26736ec003c0?narHash=sha256-RMyTyFHN3w8zwfpgvcfRHQ4vX4zTqhuZbif/MXROtx8%3D' (2025-04-16)
  → 'github:oxalica/rust-overlay/9f3d63d569536cd661a4adcf697e32eb08d61e31?narHash=sha256-M4X/CnquHozzgwDk%2BCbFb8Sb4rSGJttfNOKcpRwziis%3D' (2025-04-17)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
