### PR TITLE
Updating flake inputs Fri Apr 18 05:15:32 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744833442,
-        "narHash": "sha256-BBMWW2m64Grcc5FlXz74+vdkUyCJOfUGnl+VcS/4x44=",
+        "lastModified": 1744919155,
+        "narHash": "sha256-IJksPW32V9gid9vDxoloJMRk+YGjxq5drFHBFeBkKU8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c6b75d69b6994ba68ec281bd36faebcc56097800",
+        "rev": "72526a5f7cde2ef9075637802a1e2a8d2d658f70",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744784266,
-        "narHash": "sha256-DgvMekzi/+QCVwKyvLdxabgAyxpi+iANADyoR9yTpIk=",
+        "lastModified": 1744870665,
+        "narHash": "sha256-R5jG5iydWjN+pfWi78RuAYj57lV/ZfIqocrIrE9Kzbc=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "2b6ba726da45d80205a5d636d5abb137be701ed8",
+        "rev": "1438f712c9b5575ade77eec783c6b35f70181721",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744826984,
-        "narHash": "sha256-oVRn+J9I6c6vyokjkwh8Bty+cqADFpQnmMg/A6hK0wQ=",
+        "lastModified": 1744895532,
+        "narHash": "sha256-/7XoZbYeG9EwK/pLwtsVgvXkRKjzMniZkkkE6+Y8NUs=",
         "ref": "refs/heads/master",
-        "rev": "47c785b9160c31ab360e15c7b2f849e5225ecc66",
-        "revCount": 2199,
+        "rev": "8fd044833e40440e7b9d7a2c08281f404e5f5ed7",
+        "revCount": 2204,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744857263,
-        "narHash": "sha256-M4X/CnquHozzgwDk+CbFb8Sb4rSGJttfNOKcpRwziis=",
+        "lastModified": 1744943606,
+        "narHash": "sha256-VL4swGy4uBcHvX+UR5pMeNE9uQzXfA7B37lkwet1EmA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9f3d63d569536cd661a4adcf697e32eb08d61e31",
+        "rev": "ec22cd63500f4832d1f3432d2425e0b31b0361b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Apr 18 05:15:32 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/baf680f9c8dc699f458888583423789fd41f8c19' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/72526a5f7cde2ef9075637802a1e2a8d2d658f70' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/990e6ef31bc2ad3b713917c3acd42140ee2d1216' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/1438f712c9b5575ade77eec783c6b35f70181721' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/ec22cd63500f4832d1f3432d2425e0b31b0361b1' into the Git cache...
unpacking 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/c6b75d69b6994ba68ec281bd36faebcc56097800?narHash=sha256-BBMWW2m64Grcc5FlXz74%2BvdkUyCJOfUGnl%2BVcS/4x44%3D' (2025-04-16)
  → 'github:nix-community/home-manager/72526a5f7cde2ef9075637802a1e2a8d2d658f70?narHash=sha256-IJksPW32V9gid9vDxoloJMRk%2BYGjxq5drFHBFeBkKU8%3D' (2025-04-17)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/2b6ba726da45d80205a5d636d5abb137be701ed8?narHash=sha256-DgvMekzi/%2BQCVwKyvLdxabgAyxpi%2BiANADyoR9yTpIk%3D' (2025-04-16)
  → 'github:yusdacra/nix-cargo-integration/1438f712c9b5575ade77eec783c6b35f70181721?narHash=sha256-R5jG5iydWjN%2BpfWi78RuAYj57lV/ZfIqocrIrE9Kzbc%3D' (2025-04-17)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=47c785b9160c31ab360e15c7b2f849e5225ecc66' (2025-04-16)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=8fd044833e40440e7b9d7a2c08281f404e5f5ed7' (2025-04-17)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/9f3d63d569536cd661a4adcf697e32eb08d61e31?narHash=sha256-M4X/CnquHozzgwDk%2BCbFb8Sb4rSGJttfNOKcpRwziis%3D' (2025-04-17)
  → 'github:oxalica/rust-overlay/ec22cd63500f4832d1f3432d2425e0b31b0361b1?narHash=sha256-VL4swGy4uBcHvX%2BUR5pMeNE9uQzXfA7B37lkwet1EmA%3D' (2025-04-18)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
