### PR TITLE
Updating flake inputs Sat Apr 19 05:15:20 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1744386647,
-        "narHash": "sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ=",
+        "lastModified": 1745022865,
+        "narHash": "sha256-tXL4qUlyYZEGOHUKUWjmmcvJjjLQ+4U38lPWSc8Cgdo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "d02c1cdd7ec539699aa44e6ff912e15535969803",
+        "rev": "25ca4c50039d91ad88cc0b8feacb9ad7f748dedf",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744919155,
-        "narHash": "sha256-IJksPW32V9gid9vDxoloJMRk+YGjxq5drFHBFeBkKU8=",
+        "lastModified": 1745033012,
+        "narHash": "sha256-KjBMsjCzIOWgDqTZMYIriPFmHiQcCb2RhuDh5JF0VVc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72526a5f7cde2ef9075637802a1e2a8d2d658f70",
+        "rev": "ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744870665,
-        "narHash": "sha256-R5jG5iydWjN+pfWi78RuAYj57lV/ZfIqocrIrE9Kzbc=",
+        "lastModified": 1744957054,
+        "narHash": "sha256-3Y8q2ASLZ7mCSdOlpaMC0SzZyyCGtjUE0BoV7s/Dz2w=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "1438f712c9b5575ade77eec783c6b35f70181721",
+        "rev": "a8e83a047dba142ca57aa8ce63a9f35212ce0496",
         "type": "github"
       },
       "original": {
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744857263,
-        "narHash": "sha256-M4X/CnquHozzgwDk+CbFb8Sb4rSGJttfNOKcpRwziis=",
+        "lastModified": 1745029910,
+        "narHash": "sha256-9CtbfTTQWMoOkXejxc5D+K3z/39wkQQt2YfYJW50tnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9f3d63d569536cd661a4adcf697e32eb08d61e31",
+        "rev": "50fefac8cdfd1587ac6d8678f6181e7d348201d2",
         "type": "github"
       },
       "original": {
@@ -842,11 +842,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744707583,
-        "narHash": "sha256-IPFcShGro/UUp8BmwMBkq+6KscPlWQevZi9qqIwVUWg=",
+        "lastModified": 1744961264,
+        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49d05555ccdd2592300099d6a657cc33571f4fe0",
+        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Apr 19 05:15:20 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/25ca4c50039d91ad88cc0b8feacb9ad7f748dedf' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/baf680f9c8dc699f458888583423789fd41f8c19' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/990e6ef31bc2ad3b713917c3acd42140ee2d1216' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/a8e83a047dba142ca57aa8ce63a9f35212ce0496' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/50fefac8cdfd1587ac6d8678f6181e7d348201d2' into the Git cache...
unpacking 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' into the Git cache...
unpacking 'github:numtide/treefmt-nix/8d404a69efe76146368885110f29a2ca3700bee6' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803?narHash=sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ%3D' (2025-04-11)
  → 'github:ipetkov/crane/25ca4c50039d91ad88cc0b8feacb9ad7f748dedf?narHash=sha256-tXL4qUlyYZEGOHUKUWjmmcvJjjLQ%2B4U38lPWSc8Cgdo%3D' (2025-04-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/72526a5f7cde2ef9075637802a1e2a8d2d658f70?narHash=sha256-IJksPW32V9gid9vDxoloJMRk%2BYGjxq5drFHBFeBkKU8%3D' (2025-04-17)
  → 'github:nix-community/home-manager/ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7?narHash=sha256-KjBMsjCzIOWgDqTZMYIriPFmHiQcCb2RhuDh5JF0VVc%3D' (2025-04-19)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/1438f712c9b5575ade77eec783c6b35f70181721?narHash=sha256-R5jG5iydWjN%2BpfWi78RuAYj57lV/ZfIqocrIrE9Kzbc%3D' (2025-04-17)
  → 'github:yusdacra/nix-cargo-integration/a8e83a047dba142ca57aa8ce63a9f35212ce0496?narHash=sha256-3Y8q2ASLZ7mCSdOlpaMC0SzZyyCGtjUE0BoV7s/Dz2w%3D' (2025-04-18)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/9f3d63d569536cd661a4adcf697e32eb08d61e31?narHash=sha256-M4X/CnquHozzgwDk%2BCbFb8Sb4rSGJttfNOKcpRwziis%3D' (2025-04-17)
  → 'github:oxalica/rust-overlay/50fefac8cdfd1587ac6d8678f6181e7d348201d2?narHash=sha256-9CtbfTTQWMoOkXejxc5D%2BK3z/39wkQQt2YfYJW50tnI%3D' (2025-04-19)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/49d05555ccdd2592300099d6a657cc33571f4fe0?narHash=sha256-IPFcShGro/UUp8BmwMBkq%2B6KscPlWQevZi9qqIwVUWg%3D' (2025-04-15)
  → 'github:numtide/treefmt-nix/8d404a69efe76146368885110f29a2ca3700bee6?narHash=sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI%3D' (2025-04-18)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
