### PR TITLE
Updating flake inputs Sun Apr 20 05:14:50 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1744386647,
-        "narHash": "sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ=",
+        "lastModified": 1745022865,
+        "narHash": "sha256-tXL4qUlyYZEGOHUKUWjmmcvJjjLQ+4U38lPWSc8Cgdo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "d02c1cdd7ec539699aa44e6ff912e15535969803",
+        "rev": "25ca4c50039d91ad88cc0b8feacb9ad7f748dedf",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744919155,
-        "narHash": "sha256-IJksPW32V9gid9vDxoloJMRk+YGjxq5drFHBFeBkKU8=",
+        "lastModified": 1745125917,
+        "narHash": "sha256-UIfoCpTYnt9eigHFKV8UmQ/h5UAbFc9adYBaOEBaYYk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72526a5f7cde2ef9075637802a1e2a8d2d658f70",
+        "rev": "20705949f101952182694be8e7ccd890f61824c2",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1744841719,
-        "narHash": "sha256-wsfGB84kEK1l5OyyN6dGEUD4JXfpcrEOdFyTvuspscs=",
+        "lastModified": 1745094360,
+        "narHash": "sha256-VrhJ/34Tpdg/CYUcGFLnOTIMITfHQm2LbF/Iu1eb5/E=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "990e6ef31bc2ad3b713917c3acd42140ee2d1216",
+        "rev": "dc568340d75cf6b3d9d17eed510a077ca9aa84a5",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744870665,
-        "narHash": "sha256-R5jG5iydWjN+pfWi78RuAYj57lV/ZfIqocrIrE9Kzbc=",
+        "lastModified": 1745043349,
+        "narHash": "sha256-M9nbCJRBlAyZ5JiSxFU/CvtKLmKGbShJFiicYZ7jX4w=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "1438f712c9b5575ade77eec783c6b35f70181721",
+        "rev": "93bb70c1f250d52ca2e910475ce46ac6c4bee58c",
         "type": "github"
       },
       "original": {
@@ -458,11 +458,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744518957,
-        "narHash": "sha256-RLBSWQfTL0v+7uyskC5kP6slLK1jvIuhaAh8QvB75m4=",
+        "lastModified": 1745120797,
+        "narHash": "sha256-owQ0VQ+7cSanTVPxaZMWEzI22Q4bGnuvhVjLAJBNQ3E=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "4fc9ea78c962904f4ea11046f3db37c62e8a02fd",
+        "rev": "69716041f881a2af935021c1182ed5b0cc04d40e",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
         "type": "github"
       },
       "original": {
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1744857263,
-        "narHash": "sha256-M4X/CnquHozzgwDk+CbFb8Sb4rSGJttfNOKcpRwziis=",
+        "lastModified": 1745116541,
+        "narHash": "sha256-5xzA6dTfqCfTTDCo3ipPZzrg3wp01xmcr73y4cTNMP8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9f3d63d569536cd661a4adcf697e32eb08d61e31",
+        "rev": "e2142ef330a61c02f274ac9a9cb6f8487a5d0080",
         "type": "github"
       },
       "original": {
@@ -842,11 +842,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744707583,
-        "narHash": "sha256-IPFcShGro/UUp8BmwMBkq+6KscPlWQevZi9qqIwVUWg=",
+        "lastModified": 1744961264,
+        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49d05555ccdd2592300099d6a657cc33571f4fe0",
+        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sun Apr 20 05:14:50 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/25ca4c50039d91ad88cc0b8feacb9ad7f748dedf' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/baf680f9c8dc699f458888583423789fd41f8c19' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/20705949f101952182694be8e7ccd890f61824c2' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/dc568340d75cf6b3d9d17eed510a077ca9aa84a5' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/93bb70c1f250d52ca2e910475ce46ac6c4bee58c' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/69716041f881a2af935021c1182ed5b0cc04d40e' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/e2142ef330a61c02f274ac9a9cb6f8487a5d0080' into the Git cache...
unpacking 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' into the Git cache...
unpacking 'github:numtide/treefmt-nix/8d404a69efe76146368885110f29a2ca3700bee6' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/d02c1cdd7ec539699aa44e6ff912e15535969803?narHash=sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ%3D' (2025-04-11)
  → 'github:ipetkov/crane/25ca4c50039d91ad88cc0b8feacb9ad7f748dedf?narHash=sha256-tXL4qUlyYZEGOHUKUWjmmcvJjjLQ%2B4U38lPWSc8Cgdo%3D' (2025-04-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/72526a5f7cde2ef9075637802a1e2a8d2d658f70?narHash=sha256-IJksPW32V9gid9vDxoloJMRk%2BYGjxq5drFHBFeBkKU8%3D' (2025-04-17)
  → 'github:nix-community/home-manager/20705949f101952182694be8e7ccd890f61824c2?narHash=sha256-UIfoCpTYnt9eigHFKV8UmQ/h5UAbFc9adYBaOEBaYYk%3D' (2025-04-20)
• Updated input 'jjui':
    'github:idursun/jjui/990e6ef31bc2ad3b713917c3acd42140ee2d1216?narHash=sha256-wsfGB84kEK1l5OyyN6dGEUD4JXfpcrEOdFyTvuspscs%3D' (2025-04-16)
  → 'github:idursun/jjui/dc568340d75cf6b3d9d17eed510a077ca9aa84a5?narHash=sha256-VrhJ/34Tpdg/CYUcGFLnOTIMITfHQm2LbF/Iu1eb5/E%3D' (2025-04-19)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/1438f712c9b5575ade77eec783c6b35f70181721?narHash=sha256-R5jG5iydWjN%2BpfWi78RuAYj57lV/ZfIqocrIrE9Kzbc%3D' (2025-04-17)
  → 'github:yusdacra/nix-cargo-integration/93bb70c1f250d52ca2e910475ce46ac6c4bee58c?narHash=sha256-M9nbCJRBlAyZ5JiSxFU/CvtKLmKGbShJFiicYZ7jX4w%3D' (2025-04-19)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd?narHash=sha256-RLBSWQfTL0v%2B7uyskC5kP6slLK1jvIuhaAh8QvB75m4%3D' (2025-04-13)
  → 'github:nix-community/nix-index-database/69716041f881a2af935021c1182ed5b0cc04d40e?narHash=sha256-owQ0VQ%2B7cSanTVPxaZMWEzI22Q4bGnuvhVjLAJBNQ3E%3D' (2025-04-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11?narHash=sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38%3D' (2025-04-13)
  → 'github:nixos/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c?narHash=sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs%3D' (2025-04-17)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/9f3d63d569536cd661a4adcf697e32eb08d61e31?narHash=sha256-M4X/CnquHozzgwDk%2BCbFb8Sb4rSGJttfNOKcpRwziis%3D' (2025-04-17)
  → 'github:oxalica/rust-overlay/e2142ef330a61c02f274ac9a9cb6f8487a5d0080?narHash=sha256-5xzA6dTfqCfTTDCo3ipPZzrg3wp01xmcr73y4cTNMP8%3D' (2025-04-20)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/49d05555ccdd2592300099d6a657cc33571f4fe0?narHash=sha256-IPFcShGro/UUp8BmwMBkq%2B6KscPlWQevZi9qqIwVUWg%3D' (2025-04-15)
  → 'github:numtide/treefmt-nix/8d404a69efe76146368885110f29a2ca3700bee6?narHash=sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI%3D' (2025-04-18)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
