### PR TITLE
Updating flake inputs Mon Apr 21 05:16:19 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1744859264,
-        "narHash": "sha256-yCT9DUQzJnr4KNZjrGnsZSJstsHGkY3WIZ9WqdJ7jRo=",
+        "lastModified": 1745134331,
+        "narHash": "sha256-OZitzVfqG2rBxv8jVGF40uwDzBiSBGqZYQqOZWqfIJk=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "baf680f9c8dc699f458888583423789fd41f8c19",
+        "rev": "ed85328f570011e211ac959d6d88eeb156c61211",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745125917,
-        "narHash": "sha256-UIfoCpTYnt9eigHFKV8UmQ/h5UAbFc9adYBaOEBaYYk=",
+        "lastModified": 1745205007,
+        "narHash": "sha256-k67bEcLkSo13TIBfs0CGYkJjG12aaikabMtxWbSeqr0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "20705949f101952182694be8e7ccd890f61824c2",
+        "rev": "3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     "jjui": {
       "flake": false,
       "locked": {
-        "lastModified": 1745094360,
-        "narHash": "sha256-VrhJ/34Tpdg/CYUcGFLnOTIMITfHQm2LbF/Iu1eb5/E=",
+        "lastModified": 1745178667,
+        "narHash": "sha256-Uze8u+MzHCEKdOEsQxLHyTEPkSKgFg0872tUK5ysxw0=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "dc568340d75cf6b3d9d17eed510a077ca9aa84a5",
+        "rev": "5f934be2808cd6eb662d2485c97db3d417a47958",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745043349,
-        "narHash": "sha256-M9nbCJRBlAyZ5JiSxFU/CvtKLmKGbShJFiicYZ7jX4w=",
+        "lastModified": 1745129766,
+        "narHash": "sha256-iZvHuMyHS1YEuyKZGooNtqUmo86uDsmUO3SxeN+3YWI=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "93bb70c1f250d52ca2e910475ce46ac6c4bee58c",
+        "rev": "f21c9e680e88cc9079987ee462b7daeff824f279",
         "type": "github"
       },
       "original": {
@@ -764,11 +764,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745116541,
-        "narHash": "sha256-5xzA6dTfqCfTTDCo3ipPZzrg3wp01xmcr73y4cTNMP8=",
+        "lastModified": 1745207416,
+        "narHash": "sha256-2g2TnXgJEvSvpk7ujY69pSplmM3oShhoOidZf1iHTHU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e2142ef330a61c02f274ac9a9cb6f8487a5d0080",
+        "rev": "68a0ff1a43d08aa1ec3730e7e7d06f6da0ba630a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Mon Apr 21 05:16:19 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/25ca4c50039d91ad88cc0b8feacb9ad7f748dedf' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ed85328f570011e211ac959d6d88eeb156c61211' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/5f934be2808cd6eb662d2485c97db3d417a47958' into the Git cache...
unpacking 'github:Cretezy/lazyjj/cbae43c50484547a2f41c610c740a16b4cb1e055' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/f21c9e680e88cc9079987ee462b7daeff824f279' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/69716041f881a2af935021c1182ed5b0cc04d40e' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:oxalica/rust-overlay/68a0ff1a43d08aa1ec3730e7e7d06f6da0ba630a' into the Git cache...
unpacking 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/baf680f9c8dc699f458888583423789fd41f8c19?narHash=sha256-yCT9DUQzJnr4KNZjrGnsZSJstsHGkY3WIZ9WqdJ7jRo%3D' (2025-04-17)
  → 'github:doomemacs/doomemacs/ed85328f570011e211ac959d6d88eeb156c61211?narHash=sha256-OZitzVfqG2rBxv8jVGF40uwDzBiSBGqZYQqOZWqfIJk%3D' (2025-04-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/20705949f101952182694be8e7ccd890f61824c2?narHash=sha256-UIfoCpTYnt9eigHFKV8UmQ/h5UAbFc9adYBaOEBaYYk%3D' (2025-04-20)
  → 'github:nix-community/home-manager/3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c?narHash=sha256-k67bEcLkSo13TIBfs0CGYkJjG12aaikabMtxWbSeqr0%3D' (2025-04-21)
• Updated input 'jjui':
    'github:idursun/jjui/dc568340d75cf6b3d9d17eed510a077ca9aa84a5?narHash=sha256-VrhJ/34Tpdg/CYUcGFLnOTIMITfHQm2LbF/Iu1eb5/E%3D' (2025-04-19)
  → 'github:idursun/jjui/5f934be2808cd6eb662d2485c97db3d417a47958?narHash=sha256-Uze8u%2BMzHCEKdOEsQxLHyTEPkSKgFg0872tUK5ysxw0%3D' (2025-04-20)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/93bb70c1f250d52ca2e910475ce46ac6c4bee58c?narHash=sha256-M9nbCJRBlAyZ5JiSxFU/CvtKLmKGbShJFiicYZ7jX4w%3D' (2025-04-19)
  → 'github:yusdacra/nix-cargo-integration/f21c9e680e88cc9079987ee462b7daeff824f279?narHash=sha256-iZvHuMyHS1YEuyKZGooNtqUmo86uDsmUO3SxeN%2B3YWI%3D' (2025-04-20)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/e2142ef330a61c02f274ac9a9cb6f8487a5d0080?narHash=sha256-5xzA6dTfqCfTTDCo3ipPZzrg3wp01xmcr73y4cTNMP8%3D' (2025-04-20)
  → 'github:oxalica/rust-overlay/68a0ff1a43d08aa1ec3730e7e7d06f6da0ba630a?narHash=sha256-2g2TnXgJEvSvpk7ujY69pSplmM3oShhoOidZf1iHTHU%3D' (2025-04-21)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
