### PR TITLE
Updating flake inputs Thu Apr 24 05:15:51 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1745022865,
-        "narHash": "sha256-tXL4qUlyYZEGOHUKUWjmmcvJjjLQ+4U38lPWSc8Cgdo=",
+        "lastModified": 1745454774,
+        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "25ca4c50039d91ad88cc0b8feacb9ad7f748dedf",
+        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1745134331,
-        "narHash": "sha256-OZitzVfqG2rBxv8jVGF40uwDzBiSBGqZYQqOZWqfIJk=",
+        "lastModified": 1745401153,
+        "narHash": "sha256-wgJBR2SQpNp1GrY4BRx8MoOiNuDz7Hf/mdFFjqvsN/c=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ed85328f570011e211ac959d6d88eeb156c61211",
+        "rev": "da32e8e6f233a80d54d51964d21c4b46b000323b",
         "type": "github"
       },
       "original": {
@@ -358,11 +358,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745380081,
-        "narHash": "sha256-bUy25YkdRfdWPxSyx22igWi6g3rd3HXKFg+yL4dfBPY=",
+        "lastModified": 1745439012,
+        "narHash": "sha256-TwbdiH28QK7Da2JQTqFHdb+UCJq6QbF2mtf+RxHVzEA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0e13904bd8c444ab1595f686ede5eff377e881",
+        "rev": "d31710fb2cd536b1966fee2af74e99a0816a61a8",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745302675,
-        "narHash": "sha256-8h/ozNsjUyzga2LSXz52EW4GWyakk6QzDF0vdKqkvlQ=",
+        "lastModified": 1745389067,
+        "narHash": "sha256-r1qYFwdYd0vQ1+tBYT8ZldjWkgtqOJBWJ20hkICaxnQ=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "7838207c133ea58e0c3023dc83f4809e01692e1d",
+        "rev": "feb9f572fd9caef55bf3a81894b957cab75c297c",
         "type": "github"
       },
       "original": {
@@ -865,11 +865,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745329382,
-        "narHash": "sha256-FKvwaiOnjlYU3p6exSdyjplmHuJYlOdbxos129aYFKE=",
+        "lastModified": 1745418317,
+        "narHash": "sha256-b2IvzBzvnpimRzn4ZP3RWxUfyanNZXV/XK8lFY4hIrk=",
         "ref": "refs/heads/master",
-        "rev": "cbca3af260a53b08fbae3864a5b0316aa83c7e40",
-        "revCount": 2208,
+        "rev": "6dcd56275e606396ec82f4e95fab1d736e8152a4",
+        "revCount": 2211,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -918,11 +918,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745375696,
-        "narHash": "sha256-zFRCHNRJ1Ei8GD3iP+wcedkJzLo84OO7JEu/gmhSllU=",
+        "lastModified": 1745462120,
+        "narHash": "sha256-TbVjPOl+Cg5vZ7TIn1KpQ8SOfHKD6OEgu84b6YSCfKE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "19d1b5002d43c019880dd5cc0f8420efd20d5faf",
+        "rev": "79d3acd1a7e67fb9315fa5c5556eb6adf93dc2da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Apr 24 05:15:51 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/efd36682371678e2b6da3f108fdb5c613b3ec598' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/da32e8e6f233a80d54d51964d21c4b46b000323b' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/d31710fb2cd536b1966fee2af74e99a0816a61a8' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/24872197db930a780f91a77a0ea8db660f0e03fe' into the Git cache...
unpacking 'github:Cretezy/lazyjj/d729aad58caefd48f754a81bfb32e8a32a2fba9f' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/feb9f572fd9caef55bf3a81894b957cab75c297c' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/69716041f881a2af935021c1182ed5b0cc04d40e' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:oxalica/rust-overlay/79d3acd1a7e67fb9315fa5c5556eb6adf93dc2da' into the Git cache...
unpacking 'github:Mic92/sops-nix/5e3e92b16d6fdf9923425a8d4df7496b2434f39c' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'https://nix-versions.alwaysdata.net/flake.zip/input-leap' into the Git cache...
unpacking 'github:NixOS/nixpkgs/88e992074d86ad50249de12b7fb8dbaadf8dc0c5' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/25ca4c50039d91ad88cc0b8feacb9ad7f748dedf?narHash=sha256-tXL4qUlyYZEGOHUKUWjmmcvJjjLQ%2B4U38lPWSc8Cgdo%3D' (2025-04-19)
  → 'github:ipetkov/crane/efd36682371678e2b6da3f108fdb5c613b3ec598?narHash=sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8%3D' (2025-04-24)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/ed85328f570011e211ac959d6d88eeb156c61211?narHash=sha256-OZitzVfqG2rBxv8jVGF40uwDzBiSBGqZYQqOZWqfIJk%3D' (2025-04-20)
  → 'github:doomemacs/doomemacs/da32e8e6f233a80d54d51964d21c4b46b000323b?narHash=sha256-wgJBR2SQpNp1GrY4BRx8MoOiNuDz7Hf/mdFFjqvsN/c%3D' (2025-04-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1d0e13904bd8c444ab1595f686ede5eff377e881?narHash=sha256-bUy25YkdRfdWPxSyx22igWi6g3rd3HXKFg%2ByL4dfBPY%3D' (2025-04-23)
  → 'github:nix-community/home-manager/d31710fb2cd536b1966fee2af74e99a0816a61a8?narHash=sha256-TwbdiH28QK7Da2JQTqFHdb%2BUCJq6QbF2mtf%2BRxHVzEA%3D' (2025-04-23)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/7838207c133ea58e0c3023dc83f4809e01692e1d?narHash=sha256-8h/ozNsjUyzga2LSXz52EW4GWyakk6QzDF0vdKqkvlQ%3D' (2025-04-22)
  → 'github:yusdacra/nix-cargo-integration/feb9f572fd9caef55bf3a81894b957cab75c297c?narHash=sha256-r1qYFwdYd0vQ1%2BtBYT8ZldjWkgtqOJBWJ20hkICaxnQ%3D' (2025-04-23)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=cbca3af260a53b08fbae3864a5b0316aa83c7e40' (2025-04-22)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=6dcd56275e606396ec82f4e95fab1d736e8152a4' (2025-04-23)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/19d1b5002d43c019880dd5cc0f8420efd20d5faf?narHash=sha256-zFRCHNRJ1Ei8GD3iP%2BwcedkJzLo84OO7JEu/gmhSllU%3D' (2025-04-23)
  → 'github:oxalica/rust-overlay/79d3acd1a7e67fb9315fa5c5556eb6adf93dc2da?narHash=sha256-TbVjPOl%2BCg5vZ7TIn1KpQ8SOfHKD6OEgu84b6YSCfKE%3D' (2025-04-24)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
