### PR TITLE
Updating flake inputs Fri Apr 25 05:15:41 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1745401153,
-        "narHash": "sha256-wgJBR2SQpNp1GrY4BRx8MoOiNuDz7Hf/mdFFjqvsN/c=",
+        "lastModified": 1745483329,
+        "narHash": "sha256-3jYdqfEeQ0zoJ8svX5nzh8Bjq1HClJ9AUcpNLE3U09I=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "da32e8e6f233a80d54d51964d21c4b46b000323b",
+        "rev": "303dd28db808b42a2397c0f4b9fdd71e606026ff",
         "type": "github"
       },
       "original": {
@@ -358,11 +358,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745439012,
-        "narHash": "sha256-TwbdiH28QK7Da2JQTqFHdb+UCJq6QbF2mtf+RxHVzEA=",
+        "lastModified": 1745555634,
+        "narHash": "sha256-lhVyVn1utb2UVTbyKJ6mfKB7wLTjrj14OlebvO0WU2s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d31710fb2cd536b1966fee2af74e99a0816a61a8",
+        "rev": "98f4fef7fd7b4a77245db12e33616023162bc6d9",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745389067,
-        "narHash": "sha256-r1qYFwdYd0vQ1+tBYT8ZldjWkgtqOJBWJ20hkICaxnQ=",
+        "lastModified": 1745475473,
+        "narHash": "sha256-agOKeQ5/wwJaMA3akk+X5NBlazK/KYf+4qmsQBmEWsA=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "feb9f572fd9caef55bf3a81894b957cab75c297c",
+        "rev": "36f8235765940ea5739a5f1030c1381082f514c8",
         "type": "github"
       },
       "original": {
@@ -649,11 +649,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1745377448,
+        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
         "type": "github"
       },
       "original": {
@@ -865,11 +865,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745418317,
-        "narHash": "sha256-b2IvzBzvnpimRzn4ZP3RWxUfyanNZXV/XK8lFY4hIrk=",
+        "lastModified": 1745506298,
+        "narHash": "sha256-UTrZih6C0Pbm+V22gWJ+FtwI4D2Mp6T+1t/XzKz2dhU=",
         "ref": "refs/heads/master",
-        "rev": "6dcd56275e606396ec82f4e95fab1d736e8152a4",
-        "revCount": 2211,
+        "rev": "f13afe491d169004159a033c4ad7548a7ba76271",
+        "revCount": 2212,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -918,11 +918,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745462120,
-        "narHash": "sha256-TbVjPOl+Cg5vZ7TIn1KpQ8SOfHKD6OEgu84b6YSCfKE=",
+        "lastModified": 1745548521,
+        "narHash": "sha256-xyliq8oS5OnzXjHRGr92RtmrtYI/dflf2gSEo0wMFjc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "79d3acd1a7e67fb9315fa5c5556eb6adf93dc2da",
+        "rev": "eb0afb4ac0720d55c29e88eb29432103d73ae11d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Apr 25 05:15:41 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/efd36682371678e2b6da3f108fdb5c613b3ec598' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/303dd28db808b42a2397c0f4b9fdd71e606026ff' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/98f4fef7fd7b4a77245db12e33616023162bc6d9' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/24872197db930a780f91a77a0ea8db660f0e03fe' into the Git cache...
unpacking 'github:Cretezy/lazyjj/d729aad58caefd48f754a81bfb32e8a32a2fba9f' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/36f8235765940ea5739a5f1030c1381082f514c8' into the Git cache...
unpacking 'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/69716041f881a2af935021c1182ed5b0cc04d40e' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/507b63021ada5fee621b6ca371c4fca9ca46f52c' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:oxalica/rust-overlay/eb0afb4ac0720d55c29e88eb29432103d73ae11d' into the Git cache...
unpacking 'github:Mic92/sops-nix/5e3e92b16d6fdf9923425a8d4df7496b2434f39c' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'https://nix-versions.alwaysdata.net/flake.zip/input-leap' into the Git cache...
unpacking 'github:NixOS/nixpkgs/88e992074d86ad50249de12b7fb8dbaadf8dc0c5' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/da32e8e6f233a80d54d51964d21c4b46b000323b?narHash=sha256-wgJBR2SQpNp1GrY4BRx8MoOiNuDz7Hf/mdFFjqvsN/c%3D' (2025-04-23)
  → 'github:doomemacs/doomemacs/303dd28db808b42a2397c0f4b9fdd71e606026ff?narHash=sha256-3jYdqfEeQ0zoJ8svX5nzh8Bjq1HClJ9AUcpNLE3U09I%3D' (2025-04-24)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d31710fb2cd536b1966fee2af74e99a0816a61a8?narHash=sha256-TwbdiH28QK7Da2JQTqFHdb%2BUCJq6QbF2mtf%2BRxHVzEA%3D' (2025-04-23)
  → 'github:nix-community/home-manager/98f4fef7fd7b4a77245db12e33616023162bc6d9?narHash=sha256-lhVyVn1utb2UVTbyKJ6mfKB7wLTjrj14OlebvO0WU2s%3D' (2025-04-25)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/feb9f572fd9caef55bf3a81894b957cab75c297c?narHash=sha256-r1qYFwdYd0vQ1%2BtBYT8ZldjWkgtqOJBWJ20hkICaxnQ%3D' (2025-04-23)
  → 'github:yusdacra/nix-cargo-integration/36f8235765940ea5739a5f1030c1381082f514c8?narHash=sha256-agOKeQ5/wwJaMA3akk%2BX5NBlazK/KYf%2B4qmsQBmEWsA%3D' (2025-04-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c?narHash=sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs%3D' (2025-04-17)
  → 'github:nixos/nixpkgs/507b63021ada5fee621b6ca371c4fca9ca46f52c?narHash=sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA%3D' (2025-04-23)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=6dcd56275e606396ec82f4e95fab1d736e8152a4' (2025-04-23)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=f13afe491d169004159a033c4ad7548a7ba76271' (2025-04-24)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/79d3acd1a7e67fb9315fa5c5556eb6adf93dc2da?narHash=sha256-TbVjPOl%2BCg5vZ7TIn1KpQ8SOfHKD6OEgu84b6YSCfKE%3D' (2025-04-24)
  → 'github:oxalica/rust-overlay/eb0afb4ac0720d55c29e88eb29432103d73ae11d?narHash=sha256-xyliq8oS5OnzXjHRGr92RtmrtYI/dflf2gSEo0wMFjc%3D' (2025-04-25)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
