### PR TITLE
Updating flake inputs Thu May  1 05:16:12 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1745483329,
-        "narHash": "sha256-3jYdqfEeQ0zoJ8svX5nzh8Bjq1HClJ9AUcpNLE3U09I=",
+        "lastModified": 1746000023,
+        "narHash": "sha256-JBNHvh+sNn5Tgka4Fm2ImqeGm0xTXHU4qdSPYj0b8Bw=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "303dd28db808b42a2397c0f4b9fdd71e606026ff",
+        "rev": "ca7e226e1305ed7f10762315ad48f19c330cdd72",
         "type": "github"
       },
       "original": {
@@ -358,11 +358,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745555634,
-        "narHash": "sha256-lhVyVn1utb2UVTbyKJ6mfKB7wLTjrj14OlebvO0WU2s=",
+        "lastModified": 1746040799,
+        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "98f4fef7fd7b4a77245db12e33616023162bc6d9",
+        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745351251,
-        "narHash": "sha256-2M69r3r4VeESymiJzLr2tfKBsmTcAZJsCLEYQkRKoMw=",
+        "lastModified": 1745870967,
+        "narHash": "sha256-FfodDPHMNiB4vh+v+m2k6x9o82idHM68Os9OuXpyVGY=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "24872197db930a780f91a77a0ea8db660f0e03fe",
+        "rev": "0dc74970913b5bb55dc68771b97ddefa92c64bde",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745475473,
-        "narHash": "sha256-agOKeQ5/wwJaMA3akk+X5NBlazK/KYf+4qmsQBmEWsA=",
+        "lastModified": 1745993872,
+        "narHash": "sha256-jUQKEO+xCdoTyvZDeHt9K+BS556PFreohjTBQNX8gPg=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "36f8235765940ea5739a5f1030c1381082f514c8",
+        "rev": "411d39049ba2ddd79cfe4f0f4f8097d822803fcf",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744478979,
-        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
+        "lastModified": 1745816321,
+        "narHash": "sha256-Gyh/fkCDqVNGM0BWvk+4UAS17w2UI6iwnbQQCmc1TDI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
+        "rev": "4515dacafb0ccd42e5395aacc49fd58a43027e01",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745120797,
-        "narHash": "sha256-owQ0VQ+7cSanTVPxaZMWEzI22Q4bGnuvhVjLAJBNQ3E=",
+        "lastModified": 1746054057,
+        "narHash": "sha256-iR+idGZJ191cY6NBXyVjh9QH8GVWTkvZw/w+1Igy45A=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "69716041f881a2af935021c1182ed5b0cc04d40e",
+        "rev": "13ba07d54c6ccc5af30a501df669bf3fe3dd4db8",
         "type": "github"
       },
       "original": {
@@ -649,11 +649,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745377448,
-        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
+        "lastModified": 1745998881,
+        "narHash": "sha256-vonyYAKJSlsX4n9GCsS0pHxR6yCrfqBIuGvANlkwG6U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
+        "rev": "423d2df5b04b4ee7688c3d71396e872afa236a89",
         "type": "github"
       },
       "original": {
@@ -865,11 +865,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745506298,
-        "narHash": "sha256-UTrZih6C0Pbm+V22gWJ+FtwI4D2Mp6T+1t/XzKz2dhU=",
+        "lastModified": 1745849942,
+        "narHash": "sha256-djrxOBeP2Nkk06Qsf46H8nikxALkntIG39AlVqs0G7E=",
         "ref": "refs/heads/master",
-        "rev": "f13afe491d169004159a033c4ad7548a7ba76271",
-        "revCount": 2212,
+        "rev": "f30760d6bb86d2978a5ed4df8ee45b9aa97778b4",
+        "revCount": 2218,
         "type": "git",
         "url": "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git"
       },
@@ -918,11 +918,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745548521,
-        "narHash": "sha256-xyliq8oS5OnzXjHRGr92RtmrtYI/dflf2gSEo0wMFjc=",
+        "lastModified": 1746067100,
+        "narHash": "sha256-6JeEbboDvRjLwB9kzCnmWj+f+ZnMtKOe5c2F1VBpaTs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "eb0afb4ac0720d55c29e88eb29432103d73ae11d",
+        "rev": "026e8fedefd6b167d92ed04b195c658d95ffc7a5",
         "type": "github"
       },
       "original": {
@@ -996,11 +996,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744961264,
-        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "lastModified": 1745929750,
+        "narHash": "sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "rev": "82bf32e541b30080d94e46af13d46da0708609ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu May  1 05:16:12 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:dhamidi/leader/14373a25d8693681e7917f230de555977a12d2ba' into the Git cache...
unpacking 'github:ipetkov/crane/efd36682371678e2b6da3f108fdb5c613b3ec598' into the Git cache...
unpacking 'github:coreyja/devicon-lookup/404c9cbd477b3dee0e757aa93a66d5e59b85e596' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ca7e226e1305ed7f10762315ad48f19c330cdd72' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' into the Git cache...
unpacking 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' into the Git cache...
unpacking 'github:nix-community/home-manager/5f217e5a319f6c186283b530f8c975e66c028433' into the Git cache...
unpacking 'github:tim-janik/jj-fzf/501a936d4f5843b0a3b4df37caec529fbe199c2b' into the Git cache...
unpacking 'github:idursun/jjui/0dc74970913b5bb55dc68771b97ddefa92c64bde' into the Git cache...
unpacking 'github:Cretezy/lazyjj/d729aad58caefd48f754a81bfb32e8a32a2fba9f' into the Git cache...
unpacking 'github:yusdacra/nix-cargo-integration/411d39049ba2ddd79cfe4f0f4f8097d822803fcf' into the Git cache...
unpacking 'github:LnL7/nix-darwin/4515dacafb0ccd42e5395aacc49fd58a43027e01' into the Git cache...
unpacking 'github:nix-community/nix-index-database/13ba07d54c6ccc5af30a501df669bf3fe3dd4db8' into the Git cache...
unpacking 'github:bluskript/nix-inspect/2938c8e94acca6a7f1569f478cac6ddc4877558e' into the Git cache...
unpacking 'github:vic/nix-versions/ef2fadc629f9d8a3ae22e435d81833c86b382d9f' into the Git cache...
unpacking 'github:nix-community/nixos-generators/42ee229088490e3777ed7d1162cb9e9d8c3dbb11' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/60b4904a1390ac4c89e93d95f6ed928975e525ed' into the Git cache...
unpacking 'github:nixos/nixpkgs/423d2df5b04b4ee7688c3d71396e872afa236a89' into the Git cache...
unpacking 'github:madsbv/nix-options-search/f52dc6986161570a2ffffdf337c88b503e9a58fb' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:oxalica/rust-overlay/026e8fedefd6b167d92ed04b195c658d95ffc7a5' into the Git cache...
unpacking 'github:Mic92/sops-nix/5e3e92b16d6fdf9923425a8d4df7496b2434f39c' into the Git cache...
unpacking 'github:numtide/treefmt-nix/82bf32e541b30080d94e46af13d46da0708609ea' into the Git cache...
unpacking 'github:vic/use_devshell_toml/63f65adffe7d94a237552451bd70b10372492dab' into the Git cache...
unpacking 'https://nix-versions.alwaysdata.net/flake.zip/input-leap' into the Git cache...
unpacking 'github:NixOS/nixpkgs/88e992074d86ad50249de12b7fb8dbaadf8dc0c5' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/303dd28db808b42a2397c0f4b9fdd71e606026ff?narHash=sha256-3jYdqfEeQ0zoJ8svX5nzh8Bjq1HClJ9AUcpNLE3U09I%3D' (2025-04-24)
  → 'github:doomemacs/doomemacs/ca7e226e1305ed7f10762315ad48f19c330cdd72?narHash=sha256-JBNHvh%2BsNn5Tgka4Fm2ImqeGm0xTXHU4qdSPYj0b8Bw%3D' (2025-04-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/98f4fef7fd7b4a77245db12e33616023162bc6d9?narHash=sha256-lhVyVn1utb2UVTbyKJ6mfKB7wLTjrj14OlebvO0WU2s%3D' (2025-04-25)
  → 'github:nix-community/home-manager/5f217e5a319f6c186283b530f8c975e66c028433?narHash=sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU%3D' (2025-04-30)
• Updated input 'jjui':
    'github:idursun/jjui/24872197db930a780f91a77a0ea8db660f0e03fe?narHash=sha256-2M69r3r4VeESymiJzLr2tfKBsmTcAZJsCLEYQkRKoMw%3D' (2025-04-22)
  → 'github:idursun/jjui/0dc74970913b5bb55dc68771b97ddefa92c64bde?narHash=sha256-FfodDPHMNiB4vh%2Bv%2Bm2k6x9o82idHM68Os9OuXpyVGY%3D' (2025-04-28)
• Updated input 'nci':
    'github:yusdacra/nix-cargo-integration/36f8235765940ea5739a5f1030c1381082f514c8?narHash=sha256-agOKeQ5/wwJaMA3akk%2BX5NBlazK/KYf%2B4qmsQBmEWsA%3D' (2025-04-24)
  → 'github:yusdacra/nix-cargo-integration/411d39049ba2ddd79cfe4f0f4f8097d822803fcf?narHash=sha256-jUQKEO%2BxCdoTyvZDeHt9K%2BBS556PFreohjTBQNX8gPg%3D' (2025-04-30)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b?narHash=sha256-dyN%2BteG9G82G%2Bm%2BPX/aSAagkC%2BvUv0SgUw3XkPhQodQ%3D' (2025-04-12)
  → 'github:LnL7/nix-darwin/4515dacafb0ccd42e5395aacc49fd58a43027e01?narHash=sha256-Gyh/fkCDqVNGM0BWvk%2B4UAS17w2UI6iwnbQQCmc1TDI%3D' (2025-04-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/69716041f881a2af935021c1182ed5b0cc04d40e?narHash=sha256-owQ0VQ%2B7cSanTVPxaZMWEzI22Q4bGnuvhVjLAJBNQ3E%3D' (2025-04-20)
  → 'github:nix-community/nix-index-database/13ba07d54c6ccc5af30a501df669bf3fe3dd4db8?narHash=sha256-iR%2BidGZJ191cY6NBXyVjh9QH8GVWTkvZw/w%2B1Igy45A%3D' (2025-04-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/507b63021ada5fee621b6ca371c4fca9ca46f52c?narHash=sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA%3D' (2025-04-23)
  → 'github:nixos/nixpkgs/423d2df5b04b4ee7688c3d71396e872afa236a89?narHash=sha256-vonyYAKJSlsX4n9GCsS0pHxR6yCrfqBIuGvANlkwG6U%3D' (2025-04-30)
• Updated input 'radicle':
    'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=f13afe491d169004159a033c4ad7548a7ba76271' (2025-04-24)
  → 'git+https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git?ref=refs/heads/master&rev=f30760d6bb86d2978a5ed4df8ee45b9aa97778b4' (2025-04-28)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/eb0afb4ac0720d55c29e88eb29432103d73ae11d?narHash=sha256-xyliq8oS5OnzXjHRGr92RtmrtYI/dflf2gSEo0wMFjc%3D' (2025-04-25)
  → 'github:oxalica/rust-overlay/026e8fedefd6b167d92ed04b195c658d95ffc7a5?narHash=sha256-6JeEbboDvRjLwB9kzCnmWj%2Bf%2BZnMtKOe5c2F1VBpaTs%3D' (2025-05-01)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/8d404a69efe76146368885110f29a2ca3700bee6?narHash=sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI%3D' (2025-04-18)
  → 'github:numtide/treefmt-nix/82bf32e541b30080d94e46af13d46da0708609ea?narHash=sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko%3D' (2025-04-29)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
