### PR TITLE
Updating flake inputs Thu Jun  5 05:16:45 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1748100747,
-        "narHash": "sha256-rOkgOdmLESVAbOeEM9nJTzxyI+akdk48Ed2VlktOy3Q=",
+        "lastModified": 1748878455,
+        "narHash": "sha256-CYf3CDfPZ32qwyatieklNmDstNOSQJylw8V6Qgbvzwc=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "8406c1ff22b95bd0f816de4a0223fa3ce3c82568",
+        "rev": "313e8fb48be6381aac7b42c6c742d6d363cc7d35",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748227609,
-        "narHash": "sha256-SaSdslyo6UGDpPUlmrPA4dWOEuxCy2ihRN9K6BnqYsA=",
+        "lastModified": 1749062139,
+        "narHash": "sha256-gGGLujmeWU+ZjFzfMvFMI0hp9xONsSbm88187wJr82Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d23d20f55d49d8818ac1f1b2783671e8a6725022",
+        "rev": "86b95fc1ed2b9b04a451a08ccf13d78fb421859c",
         "type": "github"
       },
       "original": {
@@ -205,16 +205,16 @@
     },
     "input-leap": {
       "locked": {
-        "lastModified": 1743472173,
-        "narHash": "sha256-xwNv3FYTC5pl4QVZ79gUxqCEvqKzcKdXycpH5UbYscw=",
+        "lastModified": 1747426788,
+        "narHash": "sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG+K+jU57JGc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88e992074d86ad50249de12b7fb8dbaadf8dc0c5",
+        "rev": "12a55407652e04dcf2309436eb06fef0d3713ef3",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "88e9920",
+        "ref": "12a5540",
         "type": "indirect"
       }
     },
@@ -231,11 +231,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748038194,
-        "narHash": "sha256-nTf8IkxW+kpIMaEZO6oCDpLLTLX2/1NZRGMqP93EGTI=",
+        "lastModified": 1749075527,
+        "narHash": "sha256-H8nRZ0eM/4bCPSe86mkhrEv+47N9IWw22XUlg+YKro0=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "842b4911abc6f1dfbf4aa6f01fbb50f7240ba392",
+        "rev": "7fabf132d890b6e8d95b50d8a52d08888f83584e",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746254942,
-        "narHash": "sha256-Y062AuRx6l+TJNX8wxZcT59SSLsqD9EedAY0mqgTtQE=",
+        "lastModified": 1749012745,
+        "narHash": "sha256-Cax/k9ZRPKqTz18vZtmqGR45pHRXM+sDvEVd4V/3NrU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "760a11c87009155afa0140d55c40e7c336d62d7a",
+        "rev": "fa6120c32f10bd2aac9e8c9a6e71528a9d9d823b",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746330942,
-        "narHash": "sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG+KhPZFFQX/0o=",
+        "lastModified": 1748751003,
+        "narHash": "sha256-i4GZdKAK97S0ZMU3w4fqgEJr0cVywzqjugt2qZPrScs=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "137fd2bd726fff343874f85601b51769b48685cc",
+        "rev": "2860bee699248d828c2ed9097a1cd82c2f991b43",
         "type": "github"
       },
       "original": {
@@ -323,11 +323,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
         "type": "github"
       },
       "original": {
@@ -395,11 +395,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746485181,
-        "narHash": "sha256-PxrrSFLaC7YuItShxmYbMgSuFFuwxBB+qsl9BZUnRvg=",
+        "lastModified": 1747603214,
+        "narHash": "sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD+9H+Wc8o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e93ee1d900ad264d65e9701a5c6f895683433386",
+        "rev": "8d215e1c981be3aa37e47aeabd4e61bb069548fd",
         "type": "github"
       },
       "original": {
@@ -460,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746216483,
-        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
         "type": "github"
       },
       "original": {
@@ -484,8 +484,8 @@
         ]
       },
       "locked": {
-        "lastModified": 312789600,
-        "narHash": "sha256-lAhV+c203eZDOZXAyBsKuDk6mCgGQhHkcfM9PJJ0mzE=",
+        "lastModified": 312768000,
+        "narHash": "sha256-HojxG64+buRSmGeTyJogbuuZ98cVKCeWeJRWKJGcmOI=",
         "type": "tarball",
         "url": "https://nix-versions.alwaysdata.net/flake.zip/input-leap"
       },


### PR DESCRIPTION
Updating flake inputs Thu Jun  5 05:16:45 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/313e8fb48be6381aac7b42c6c742d6d363cc7d35' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/49f0870db23e8c1ca0b5259734a02cd9e1e371a1' into the Git cache...
unpacking 'github:nix-community/home-manager/86b95fc1ed2b9b04a451a08ccf13d78fb421859c' into the Git cache...
unpacking 'github:idursun/jjui/7fabf132d890b6e8d95b50d8a52d08888f83584e' into the Git cache...
unpacking 'github:LnL7/nix-darwin/fa6120c32f10bd2aac9e8c9a6e71528a9d9d823b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/2860bee699248d828c2ed9097a1cd82c2f991b43' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/be618645aa0adf461f778500172b6896d5ab2d01' into the Git cache...
unpacking 'github:nixos/nixpkgs/e4b09e47ace7d87de083786b404bf232eb6c89d8' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:Mic92/sops-nix/8d215e1c981be3aa37e47aeabd4e61bb069548fd' into the Git cache...
unpacking 'github:numtide/treefmt-nix/1f3f7b784643d488ba4bf315638b2b0a4c5fb007' into the Git cache...
unpacking 'https://nix-versions.alwaysdata.net/flake.zip/input-leap' into the Git cache...
unpacking 'github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/8406c1ff22b95bd0f816de4a0223fa3ce3c82568?narHash=sha256-rOkgOdmLESVAbOeEM9nJTzxyI%2Bakdk48Ed2VlktOy3Q%3D' (2025-05-24)
  → 'github:doomemacs/doomemacs/313e8fb48be6381aac7b42c6c742d6d363cc7d35?narHash=sha256-CYf3CDfPZ32qwyatieklNmDstNOSQJylw8V6Qgbvzwc%3D' (2025-06-02)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
  → 'github:hercules-ci/flake-parts/49f0870db23e8c1ca0b5259734a02cd9e1e371a1?narHash=sha256-F82%2BgS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE%3D' (2025-06-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/e4822aea2a6d1cdd36653c134cacfd64c97ff4fa?narHash=sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc%3D' (2025-03-30)
  → 'github:nix-community/nixpkgs.lib/656a64127e9d791a334452c6b6606d17539476e2?narHash=sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc%3D' (2025-06-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d23d20f55d49d8818ac1f1b2783671e8a6725022?narHash=sha256-SaSdslyo6UGDpPUlmrPA4dWOEuxCy2ihRN9K6BnqYsA%3D' (2025-05-26)
  → 'github:nix-community/home-manager/86b95fc1ed2b9b04a451a08ccf13d78fb421859c?narHash=sha256-gGGLujmeWU%2BZjFzfMvFMI0hp9xONsSbm88187wJr82Q%3D' (2025-06-04)
• Updated input 'jjui':
    'github:idursun/jjui/842b4911abc6f1dfbf4aa6f01fbb50f7240ba392?narHash=sha256-nTf8IkxW%2BkpIMaEZO6oCDpLLTLX2/1NZRGMqP93EGTI%3D' (2025-05-23)
  → 'github:idursun/jjui/7fabf132d890b6e8d95b50d8a52d08888f83584e?narHash=sha256-H8nRZ0eM/4bCPSe86mkhrEv%2B47N9IWw22XUlg%2BYKro0%3D' (2025-06-04)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/760a11c87009155afa0140d55c40e7c336d62d7a?narHash=sha256-Y062AuRx6l%2BTJNX8wxZcT59SSLsqD9EedAY0mqgTtQE%3D' (2025-05-03)
  → 'github:LnL7/nix-darwin/fa6120c32f10bd2aac9e8c9a6e71528a9d9d823b?narHash=sha256-Cax/k9ZRPKqTz18vZtmqGR45pHRXM%2BsDvEVd4V/3NrU%3D' (2025-06-04)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/137fd2bd726fff343874f85601b51769b48685cc?narHash=sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG%2BKhPZFFQX/0o%3D' (2025-05-04)
  → 'github:nix-community/nix-index-database/2860bee699248d828c2ed9097a1cd82c2f991b43?narHash=sha256-i4GZdKAK97S0ZMU3w4fqgEJr0cVywzqjugt2qZPrScs%3D' (2025-06-01)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/e93ee1d900ad264d65e9701a5c6f895683433386?narHash=sha256-PxrrSFLaC7YuItShxmYbMgSuFFuwxBB%2Bqsl9BZUnRvg%3D' (2025-05-05)
  → 'github:Mic92/sops-nix/8d215e1c981be3aa37e47aeabd4e61bb069548fd?narHash=sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD%2B9H%2BWc8o%3D' (2025-05-18)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/29ec5026372e0dec56f890e50dbe4f45930320fd?narHash=sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4%3D' (2025-05-02)
  → 'github:numtide/treefmt-nix/1f3f7b784643d488ba4bf315638b2b0a4c5fb007?narHash=sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8%3D' (2025-05-26)
• Updated input 'versioned':
    'https://nix-versions.alwaysdata.net/flake.zip/input-leap?narHash=sha256-lAhV%2Bc203eZDOZXAyBsKuDk6mCgGQhHkcfM9PJJ0mzE%3D' (1979-11-30)
  → 'https://nix-versions.alwaysdata.net/flake.zip/input-leap?narHash=sha256-HojxG64%2BbuRSmGeTyJogbuuZ98cVKCeWeJRWKJGcmOI%3D' (1979-11-30)
• Updated input 'versioned/input-leap':
    'github:NixOS/nixpkgs/88e992074d86ad50249de12b7fb8dbaadf8dc0c5?narHash=sha256-xwNv3FYTC5pl4QVZ79gUxqCEvqKzcKdXycpH5UbYscw%3D' (2025-04-01)
  → 'github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3?narHash=sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG%2BK%2BjU57JGc%3D' (2025-05-16)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
