### PR TITLE
Updating flake inputs Wed Jun 11 05:17:14 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1748100747,
-        "narHash": "sha256-rOkgOdmLESVAbOeEM9nJTzxyI+akdk48Ed2VlktOy3Q=",
+        "lastModified": 1749598192,
+        "narHash": "sha256-PdCOQtE+gkfn0Hmx136Zfw2g1tcy8Mf8wkknrITm6Qg=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "8406c1ff22b95bd0f816de4a0223fa3ce3c82568",
+        "rev": "442f4db4d43dfea5304dd32fcff39a77ec439e37",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748227609,
-        "narHash": "sha256-SaSdslyo6UGDpPUlmrPA4dWOEuxCy2ihRN9K6BnqYsA=",
+        "lastModified": 1749526396,
+        "narHash": "sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d23d20f55d49d8818ac1f1b2783671e8a6725022",
+        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
         "type": "github"
       },
       "original": {
@@ -205,16 +205,16 @@
     },
     "input-leap": {
       "locked": {
-        "lastModified": 1743472173,
-        "narHash": "sha256-xwNv3FYTC5pl4QVZ79gUxqCEvqKzcKdXycpH5UbYscw=",
+        "lastModified": 1747426788,
+        "narHash": "sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG+K+jU57JGc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88e992074d86ad50249de12b7fb8dbaadf8dc0c5",
+        "rev": "12a55407652e04dcf2309436eb06fef0d3713ef3",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "88e9920",
+        "ref": "12a5540",
         "type": "indirect"
       }
     },
@@ -231,11 +231,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748038194,
-        "narHash": "sha256-nTf8IkxW+kpIMaEZO6oCDpLLTLX2/1NZRGMqP93EGTI=",
+        "lastModified": 1749484724,
+        "narHash": "sha256-f7QnkL58Q42DrEdSNFnduRq64wUFXrqOMMjKCL/UG2k=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "842b4911abc6f1dfbf4aa6f01fbb50f7240ba392",
+        "rev": "09942746e2b251ba63a98e7d48b9b1e523865e6b",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746254942,
-        "narHash": "sha256-Y062AuRx6l+TJNX8wxZcT59SSLsqD9EedAY0mqgTtQE=",
+        "lastModified": 1749194393,
+        "narHash": "sha256-vt6hM9DNywnXXuW1qPDLzECmbDcmxhh58wpb0EEQjAo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "760a11c87009155afa0140d55c40e7c336d62d7a",
+        "rev": "19346808c445f23b08652971be198b9df6c33edc",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746330942,
-        "narHash": "sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG+KhPZFFQX/0o=",
+        "lastModified": 1749355504,
+        "narHash": "sha256-L17CdJMD+/FCBOHjREQLXbe2VUnc3rjffenBbu2Kwpc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "137fd2bd726fff343874f85601b51769b48685cc",
+        "rev": "40a6e15e44b11fbf8f2b1df9d64dbfc117625e94",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746453552,
-        "narHash": "sha256-r66UGha+7KVHkI7ksrcMjnw/mm9Sg4l5bQlylxHwdGU=",
+        "lastModified": 1749574455,
+        "narHash": "sha256-fm2/8KPOYvvIAnNVtjDlTt/My00lIbZQ+LMrfQIWVzs=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "be618645aa0adf461f778500172b6896d5ab2d01",
+        "rev": "917af390377c573932d84b5e31dd9f2c1b5c0f09",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748856973,
-        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "lastModified": 1749558678,
+        "narHash": "sha256-DUVAe8E2X2QM0dAnTGlTiqemMqUMMyIeCH7UeNo0g64=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "rev": "a12f3a99614894502e73eb816e9e076b0ab05730",
         "type": "github"
       },
       "original": {
@@ -323,11 +323,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
         "type": "github"
       },
       "original": {
@@ -395,11 +395,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746485181,
-        "narHash": "sha256-PxrrSFLaC7YuItShxmYbMgSuFFuwxBB+qsl9BZUnRvg=",
+        "lastModified": 1749592509,
+        "narHash": "sha256-VunQzfZFA+Y6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC+A=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e93ee1d900ad264d65e9701a5c6f895683433386",
+        "rev": "50754dfaa0e24e313c626900d44ef431f3210138",
         "type": "github"
       },
       "original": {
@@ -460,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746216483,
-        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
+        "lastModified": 1749194973,
+        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
+        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
         "type": "github"
       },
       "original": {
@@ -484,8 +484,8 @@
         ]
       },
       "locked": {
-        "lastModified": 312789600,
-        "narHash": "sha256-lAhV+c203eZDOZXAyBsKuDk6mCgGQhHkcfM9PJJ0mzE=",
+        "lastModified": 312768000,
+        "narHash": "sha256-HojxG64+buRSmGeTyJogbuuZ98cVKCeWeJRWKJGcmOI=",
         "type": "tarball",
         "url": "https://nix-versions.alwaysdata.net/flake.zip/input-leap"
       },


### PR DESCRIPTION
Updating flake inputs Wed Jun 11 05:17:14 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/442f4db4d43dfea5304dd32fcff39a77ec439e37' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569' into the Git cache...
unpacking 'github:nix-community/home-manager/427c96044f11a5da50faf6adaf38c9fa47e6d044' into the Git cache...
unpacking 'github:idursun/jjui/09942746e2b251ba63a98e7d48b9b1e523865e6b' into the Git cache...
unpacking 'github:LnL7/nix-darwin/19346808c445f23b08652971be198b9df6c33edc' into the Git cache...
unpacking 'github:nix-community/nix-index-database/40a6e15e44b11fbf8f2b1df9d64dbfc117625e94' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/a12f3a99614894502e73eb816e9e076b0ab05730' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:Mic92/sops-nix/50754dfaa0e24e313c626900d44ef431f3210138' into the Git cache...
unpacking 'github:numtide/treefmt-nix/a05be418a1af1198ca0f63facb13c985db4cb3c5' into the Git cache...
unpacking 'https://nix-versions.alwaysdata.net/flake.zip/input-leap' into the Git cache...
unpacking 'github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/8b6db451de46ecf9b4ab3d01ef76e59957ff549f' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/8406c1ff22b95bd0f816de4a0223fa3ce3c82568?narHash=sha256-rOkgOdmLESVAbOeEM9nJTzxyI%2Bakdk48Ed2VlktOy3Q%3D' (2025-05-24)
  → 'github:doomemacs/doomemacs/442f4db4d43dfea5304dd32fcff39a77ec439e37?narHash=sha256-PdCOQtE%2Bgkfn0Hmx136Zfw2g1tcy8Mf8wkknrITm6Qg%3D' (2025-06-10)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
  → 'github:hercules-ci/flake-parts/9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569?narHash=sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98%3D' (2025-06-08)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/e4822aea2a6d1cdd36653c134cacfd64c97ff4fa?narHash=sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc%3D' (2025-03-30)
  → 'github:nix-community/nixpkgs.lib/656a64127e9d791a334452c6b6606d17539476e2?narHash=sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc%3D' (2025-06-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d23d20f55d49d8818ac1f1b2783671e8a6725022?narHash=sha256-SaSdslyo6UGDpPUlmrPA4dWOEuxCy2ihRN9K6BnqYsA%3D' (2025-05-26)
  → 'github:nix-community/home-manager/427c96044f11a5da50faf6adaf38c9fa47e6d044?narHash=sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo%3D' (2025-06-10)
• Updated input 'jjui':
    'github:idursun/jjui/842b4911abc6f1dfbf4aa6f01fbb50f7240ba392?narHash=sha256-nTf8IkxW%2BkpIMaEZO6oCDpLLTLX2/1NZRGMqP93EGTI%3D' (2025-05-23)
  → 'github:idursun/jjui/09942746e2b251ba63a98e7d48b9b1e523865e6b?narHash=sha256-f7QnkL58Q42DrEdSNFnduRq64wUFXrqOMMjKCL/UG2k%3D' (2025-06-09)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/760a11c87009155afa0140d55c40e7c336d62d7a?narHash=sha256-Y062AuRx6l%2BTJNX8wxZcT59SSLsqD9EedAY0mqgTtQE%3D' (2025-05-03)
  → 'github:LnL7/nix-darwin/19346808c445f23b08652971be198b9df6c33edc?narHash=sha256-vt6hM9DNywnXXuW1qPDLzECmbDcmxhh58wpb0EEQjAo%3D' (2025-06-06)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/137fd2bd726fff343874f85601b51769b48685cc?narHash=sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG%2BKhPZFFQX/0o%3D' (2025-05-04)
  → 'github:nix-community/nix-index-database/40a6e15e44b11fbf8f2b1df9d64dbfc117625e94?narHash=sha256-L17CdJMD%2B/FCBOHjREQLXbe2VUnc3rjffenBbu2Kwpc%3D' (2025-06-08)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/be618645aa0adf461f778500172b6896d5ab2d01?narHash=sha256-r66UGha%2B7KVHkI7ksrcMjnw/mm9Sg4l5bQlylxHwdGU%3D' (2025-05-05)
  → 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09?narHash=sha256-fm2/8KPOYvvIAnNVtjDlTt/My00lIbZQ%2BLMrfQIWVzs%3D' (2025-06-10)
• Updated input 'nixos-wsl/flake-compat':
    'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
  → 'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e4b09e47ace7d87de083786b404bf232eb6c89d8?narHash=sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg%3D' (2025-06-02)
  → 'github:nixos/nixpkgs/a12f3a99614894502e73eb816e9e076b0ab05730?narHash=sha256-DUVAe8E2X2QM0dAnTGlTiqemMqUMMyIeCH7UeNo0g64%3D' (2025-06-10)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/e93ee1d900ad264d65e9701a5c6f895683433386?narHash=sha256-PxrrSFLaC7YuItShxmYbMgSuFFuwxBB%2Bqsl9BZUnRvg%3D' (2025-05-05)
  → 'github:Mic92/sops-nix/50754dfaa0e24e313c626900d44ef431f3210138?narHash=sha256-VunQzfZFA%2BY6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC%2BA%3D' (2025-06-10)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/29ec5026372e0dec56f890e50dbe4f45930320fd?narHash=sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4%3D' (2025-05-02)
  → 'github:numtide/treefmt-nix/a05be418a1af1198ca0f63facb13c985db4cb3c5?narHash=sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk%3D' (2025-06-06)
• Updated input 'versioned':
    'https://nix-versions.alwaysdata.net/flake.zip/input-leap?narHash=sha256-lAhV%2Bc203eZDOZXAyBsKuDk6mCgGQhHkcfM9PJJ0mzE%3D' (1979-11-30)
  → 'https://nix-versions.alwaysdata.net/flake.zip/input-leap?narHash=sha256-HojxG64%2BbuRSmGeTyJogbuuZ98cVKCeWeJRWKJGcmOI%3D' (1979-11-30)
• Updated input 'versioned/input-leap':
    'github:NixOS/nixpkgs/88e992074d86ad50249de12b7fb8dbaadf8dc0c5?narHash=sha256-xwNv3FYTC5pl4QVZ79gUxqCEvqKzcKdXycpH5UbYscw%3D' (2025-04-01)
  → 'github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3?narHash=sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG%2BK%2BjU57JGc%3D' (2025-05-16)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
