### PR TITLE
Updating flake inputs Sat Jun 21 05:15:17 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750372489,
-        "narHash": "sha256-ibsjw9yzDPcs44htKxBskKchkvtRVA9VtmW67jVple8=",
+        "lastModified": 1750456174,
+        "narHash": "sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "38cc7d12e1f4c73050b8cbd4e705bb58a001959f",
+        "rev": "0acafb9f533dfc4ca5a43f1341b07ccdb78d5410",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Jun 21 05:15:17 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/e6c755305358412a71a990fc2cf592c629edde1e' into the Git cache...
unpacking 'github:idursun/jjui/0acafb9f533dfc4ca5a43f1341b07ccdb78d5410' into the Git cache...
unpacking 'github:LnL7/nix-darwin/0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9' into the Git cache...
unpacking 'github:nix-community/nix-index-database/424a40050cdc5f494ec45e46462d288f08c64475' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/5395fb3ab3f97b9b7abca147249fa2e8ed27b192' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:Mic92/sops-nix/77c423a03b9b2b79709ea2cb63336312e78b72e2' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'jjui':
    'github:idursun/jjui/38cc7d12e1f4c73050b8cbd4e705bb58a001959f?narHash=sha256-ibsjw9yzDPcs44htKxBskKchkvtRVA9VtmW67jVple8%3D' (2025-06-19)
  → 'github:idursun/jjui/0acafb9f533dfc4ca5a43f1341b07ccdb78d5410?narHash=sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo%3D' (2025-06-20)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
