### PR TITLE
Updating flake inputs Sun Jun 22 05:16:01 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1749958812,
-        "narHash": "sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ=",
+        "lastModified": 1750551828,
+        "narHash": "sha256-9s17jsgch7tE/qRd/BrImjj6gj9JIs4GKRYi901Eqrg=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "6fcfa909614de6dd6c712db8229b8c0261791e39",
+        "rev": "39623fae9e2d67511f4bdfc249ca6beccebbd810",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750372489,
-        "narHash": "sha256-ibsjw9yzDPcs44htKxBskKchkvtRVA9VtmW67jVple8=",
+        "lastModified": 1750555070,
+        "narHash": "sha256-VsNYTMDyU6VMx4DT9B/7qbS2yIZG1hNSi8V+Sxwm854=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "38cc7d12e1f4c73050b8cbd4e705bb58a001959f",
+        "rev": "5a6a4c14b69a290526eefc66ae7f583cc257c520",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750325256,
-        "narHash": "sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0=",
+        "lastModified": 1750558694,
+        "narHash": "sha256-BVFZLpbQ3YJHp+IVAudMZJpdL+QrhF1RNmLJZp1nWSw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9",
+        "rev": "ff139e81835fc150c4615f25eae215e904a717d2",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749960154,
-        "narHash": "sha256-EWlr9MZDd+GoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg=",
+        "lastModified": 1750565152,
+        "narHash": "sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "424a40050cdc5f494ec45e46462d288f08c64475",
+        "rev": "78cd697acc2e492b4e92822a4913ffad279c20e6",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750215678,
-        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
+        "lastModified": 1750386251,
+        "narHash": "sha256-1ovgdmuDYVo5OUC5NzdF+V4zx2uT8RtsgZahxidBTyw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
+        "rev": "076e8c6678d8c54204abcb4b1b14c366835a58bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sun Jun 22 05:16:01 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/e6c755305358412a71a990fc2cf592c629edde1e' into the Git cache...
unpacking 'github:vic/import-tree/39623fae9e2d67511f4bdfc249ca6beccebbd810' into the Git cache...
unpacking 'github:idursun/jjui/5a6a4c14b69a290526eefc66ae7f583cc257c520' into the Git cache...
unpacking 'github:LnL7/nix-darwin/ff139e81835fc150c4615f25eae215e904a717d2' into the Git cache...
unpacking 'github:nix-community/nix-index-database/78cd697acc2e492b4e92822a4913ffad279c20e6' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:Mic92/sops-nix/77c423a03b9b2b79709ea2cb63336312e78b72e2' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'import-tree':
    'github:vic/import-tree/6fcfa909614de6dd6c712db8229b8c0261791e39?narHash=sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ%3D' (2025-06-15)
  → 'github:vic/import-tree/39623fae9e2d67511f4bdfc249ca6beccebbd810?narHash=sha256-9s17jsgch7tE/qRd/BrImjj6gj9JIs4GKRYi901Eqrg%3D' (2025-06-22)
• Updated input 'jjui':
    'github:idursun/jjui/38cc7d12e1f4c73050b8cbd4e705bb58a001959f?narHash=sha256-ibsjw9yzDPcs44htKxBskKchkvtRVA9VtmW67jVple8%3D' (2025-06-19)
  → 'github:idursun/jjui/5a6a4c14b69a290526eefc66ae7f583cc257c520?narHash=sha256-VsNYTMDyU6VMx4DT9B/7qbS2yIZG1hNSi8V%2BSxwm854%3D' (2025-06-22)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9?narHash=sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0%3D' (2025-06-19)
  → 'github:LnL7/nix-darwin/ff139e81835fc150c4615f25eae215e904a717d2?narHash=sha256-BVFZLpbQ3YJHp%2BIVAudMZJpdL%2BQrhF1RNmLJZp1nWSw%3D' (2025-06-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/424a40050cdc5f494ec45e46462d288f08c64475?narHash=sha256-EWlr9MZDd%2BGoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg%3D' (2025-06-15)
  → 'github:nix-community/nix-index-database/78cd697acc2e492b4e92822a4913ffad279c20e6?narHash=sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM%3D' (2025-06-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5395fb3ab3f97b9b7abca147249fa2e8ed27b192?narHash=sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M%2Bok%3D' (2025-06-18)
  → 'github:nixos/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb?narHash=sha256-1ovgdmuDYVo5OUC5NzdF%2BV4zx2uT8RtsgZahxidBTyw%3D' (2025-06-20)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
