### PR TITLE
Updating flake inputs Wed Jun 25 05:17:50 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750304462,
-        "narHash": "sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc=",
+        "lastModified": 1750798083,
+        "narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "863842639722dd12ae9e37ca83bcb61a63b36f6c",
+        "rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1749958812,
-        "narHash": "sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ=",
+        "lastModified": 1750792846,
+        "narHash": "sha256-+1Jo6ucb+vHGrSm6bjaGl52QTijk3vwNHQKdtoefhqc=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "6fcfa909614de6dd6c712db8229b8c0261791e39",
+        "rev": "a062c831c6f8ecc320627f3f7ce539781a76e52f",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750456174,
-        "narHash": "sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo=",
+        "lastModified": 1750710797,
+        "narHash": "sha256-IwjB9G4C4lpDOHC6TCcikVFeJldPwvLMK4gLKCW/f9U=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "0acafb9f533dfc4ca5a43f1341b07ccdb78d5410",
+        "rev": "ff98b4b797838f160c9de62b34a2e85680eeb55c",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750325256,
-        "narHash": "sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0=",
+        "lastModified": 1750618568,
+        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9",
+        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749960154,
-        "narHash": "sha256-EWlr9MZDd+GoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg=",
+        "lastModified": 1750565152,
+        "narHash": "sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "424a40050cdc5f494ec45e46462d288f08c64475",
+        "rev": "78cd697acc2e492b4e92822a4913ffad279c20e6",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750215678,
-        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
+        "lastModified": 1750731501,
+        "narHash": "sha256-Ah4qq+SbwMaGkuXCibyg+Fwn00el4KmI3XFX6htfDuk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
+        "rev": "69dfebb3d175bde602f612915c5576a41b18486b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Jun 25 05:17:50 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/e6c755305358412a71a990fc2cf592c629edde1e' into the Git cache...
unpacking 'github:nix-community/home-manager/ff31a4677c1a8ae506aa7e003a3dba08cb203f82' into the Git cache...
unpacking 'github:vic/import-tree/a062c831c6f8ecc320627f3f7ce539781a76e52f' into the Git cache...
unpacking 'github:idursun/jjui/ff98b4b797838f160c9de62b34a2e85680eeb55c' into the Git cache...
unpacking 'github:LnL7/nix-darwin/1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5' into the Git cache...
unpacking 'github:nix-community/nix-index-database/78cd697acc2e492b4e92822a4913ffad279c20e6' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/69dfebb3d175bde602f612915c5576a41b18486b' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:Mic92/sops-nix/77c423a03b9b2b79709ea2cb63336312e78b72e2' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/863842639722dd12ae9e37ca83bcb61a63b36f6c?narHash=sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc%3D' (2025-06-19)
  → 'github:nix-community/home-manager/ff31a4677c1a8ae506aa7e003a3dba08cb203f82?narHash=sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8%2B/0R8Wc4%3D' (2025-06-24)
• Updated input 'import-tree':
    'github:vic/import-tree/6fcfa909614de6dd6c712db8229b8c0261791e39?narHash=sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ%3D' (2025-06-15)
  → 'github:vic/import-tree/a062c831c6f8ecc320627f3f7ce539781a76e52f?narHash=sha256-%2B1Jo6ucb%2BvHGrSm6bjaGl52QTijk3vwNHQKdtoefhqc%3D' (2025-06-24)
• Updated input 'jjui':
    'github:idursun/jjui/0acafb9f533dfc4ca5a43f1341b07ccdb78d5410?narHash=sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo%3D' (2025-06-20)
  → 'github:idursun/jjui/ff98b4b797838f160c9de62b34a2e85680eeb55c?narHash=sha256-IwjB9G4C4lpDOHC6TCcikVFeJldPwvLMK4gLKCW/f9U%3D' (2025-06-23)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9?narHash=sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0%3D' (2025-06-19)
  → 'github:LnL7/nix-darwin/1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5?narHash=sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E%3D' (2025-06-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/424a40050cdc5f494ec45e46462d288f08c64475?narHash=sha256-EWlr9MZDd%2BGoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg%3D' (2025-06-15)
  → 'github:nix-community/nix-index-database/78cd697acc2e492b4e92822a4913ffad279c20e6?narHash=sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM%3D' (2025-06-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5395fb3ab3f97b9b7abca147249fa2e8ed27b192?narHash=sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M%2Bok%3D' (2025-06-18)
  → 'github:nixos/nixpkgs/69dfebb3d175bde602f612915c5576a41b18486b?narHash=sha256-Ah4qq%2BSbwMaGkuXCibyg%2BFwn00el4KmI3XFX6htfDuk%3D' (2025-06-24)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
