### PR TITLE
Updating flake inputs Fri Jun 27 05:17:12 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1749895289,
-        "narHash": "sha256-b1Hl70p4OOWkcTtXRiJ3Ker9gzOjAoZfwNqxlmE1s7g=",
+        "lastModified": 1750971277,
+        "narHash": "sha256-yqeuL5N6q0j6U66k4KvOx96uI/IZqQeBh1LlapTpbvY=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "e6c755305358412a71a990fc2cf592c629edde1e",
+        "rev": "3d75d8e205eb0c0def40920be6e30469eb5f4769",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750304462,
-        "narHash": "sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc=",
+        "lastModified": 1750973805,
+        "narHash": "sha256-BZXgag7I0rnL/HMHAsBz3tQrfKAibpY2vovexl2lS+Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "863842639722dd12ae9e37ca83bcb61a63b36f6c",
+        "rev": "080e8b48b0318b38143d5865de9334f46d51fce3",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1749958812,
-        "narHash": "sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ=",
+        "lastModified": 1750911390,
+        "narHash": "sha256-1v9yCEDYczPO+NiMvjBcHUrCxpfXyqJDnYjhmBuMlvA=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "6fcfa909614de6dd6c712db8229b8c0261791e39",
+        "rev": "16710e6d4ebc5b1134d5d63e7aa10a8ec8a564cf",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750456174,
-        "narHash": "sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo=",
+        "lastModified": 1750893430,
+        "narHash": "sha256-/DSphZ0zYtZa//InV7fdqMfSRp/h8ufQp1oUQakyXYM=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "0acafb9f533dfc4ca5a43f1341b07ccdb78d5410",
+        "rev": "09f0b4f4fc5d2ea968514de9bd9c70256564dd07",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750325256,
-        "narHash": "sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0=",
+        "lastModified": 1750618568,
+        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9",
+        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749960154,
-        "narHash": "sha256-EWlr9MZDd+GoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg=",
+        "lastModified": 1750565152,
+        "narHash": "sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "424a40050cdc5f494ec45e46462d288f08c64475",
+        "rev": "78cd697acc2e492b4e92822a4913ffad279c20e6",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750215678,
-        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
+        "lastModified": 1750898778,
+        "narHash": "sha256-DXI7+SKDlTyA+C4zp0LoIywQ+BfdH5m4nkuxbWgV4UU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
+        "rev": "322d8a3c6940039f7cff179a8b09c5d7ca06359d",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749194973,
-        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "lastModified": 1750931469,
+        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Jun 27 05:17:12 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/3d75d8e205eb0c0def40920be6e30469eb5f4769' into the Git cache...
unpacking 'github:nix-community/home-manager/080e8b48b0318b38143d5865de9334f46d51fce3' into the Git cache...
unpacking 'github:vic/import-tree/16710e6d4ebc5b1134d5d63e7aa10a8ec8a564cf' into the Git cache...
unpacking 'github:idursun/jjui/09f0b4f4fc5d2ea968514de9bd9c70256564dd07' into the Git cache...
unpacking 'github:LnL7/nix-darwin/1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5' into the Git cache...
unpacking 'github:nix-community/nix-index-database/78cd697acc2e492b4e92822a4913ffad279c20e6' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/322d8a3c6940039f7cff179a8b09c5d7ca06359d' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:Mic92/sops-nix/77c423a03b9b2b79709ea2cb63336312e78b72e2' into the Git cache...
unpacking 'github:numtide/treefmt-nix/ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/e6c755305358412a71a990fc2cf592c629edde1e?narHash=sha256-b1Hl70p4OOWkcTtXRiJ3Ker9gzOjAoZfwNqxlmE1s7g%3D' (2025-06-14)
  → 'github:doomemacs/doomemacs/3d75d8e205eb0c0def40920be6e30469eb5f4769?narHash=sha256-yqeuL5N6q0j6U66k4KvOx96uI/IZqQeBh1LlapTpbvY%3D' (2025-06-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/863842639722dd12ae9e37ca83bcb61a63b36f6c?narHash=sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc%3D' (2025-06-19)
  → 'github:nix-community/home-manager/080e8b48b0318b38143d5865de9334f46d51fce3?narHash=sha256-BZXgag7I0rnL/HMHAsBz3tQrfKAibpY2vovexl2lS%2BY%3D' (2025-06-26)
• Updated input 'import-tree':
    'github:vic/import-tree/6fcfa909614de6dd6c712db8229b8c0261791e39?narHash=sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ%3D' (2025-06-15)
  → 'github:vic/import-tree/16710e6d4ebc5b1134d5d63e7aa10a8ec8a564cf?narHash=sha256-1v9yCEDYczPO%2BNiMvjBcHUrCxpfXyqJDnYjhmBuMlvA%3D' (2025-06-26)
• Updated input 'jjui':
    'github:idursun/jjui/0acafb9f533dfc4ca5a43f1341b07ccdb78d5410?narHash=sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo%3D' (2025-06-20)
  → 'github:idursun/jjui/09f0b4f4fc5d2ea968514de9bd9c70256564dd07?narHash=sha256-/DSphZ0zYtZa//InV7fdqMfSRp/h8ufQp1oUQakyXYM%3D' (2025-06-25)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9?narHash=sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0%3D' (2025-06-19)
  → 'github:LnL7/nix-darwin/1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5?narHash=sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E%3D' (2025-06-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/424a40050cdc5f494ec45e46462d288f08c64475?narHash=sha256-EWlr9MZDd%2BGoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg%3D' (2025-06-15)
  → 'github:nix-community/nix-index-database/78cd697acc2e492b4e92822a4913ffad279c20e6?narHash=sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM%3D' (2025-06-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5395fb3ab3f97b9b7abca147249fa2e8ed27b192?narHash=sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M%2Bok%3D' (2025-06-18)
  → 'github:nixos/nixpkgs/322d8a3c6940039f7cff179a8b09c5d7ca06359d?narHash=sha256-DXI7%2BSKDlTyA%2BC4zp0LoIywQ%2BBfdH5m4nkuxbWgV4UU%3D' (2025-06-26)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/a05be418a1af1198ca0f63facb13c985db4cb3c5?narHash=sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk%3D' (2025-06-06)
  → 'github:numtide/treefmt-nix/ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1?narHash=sha256-0IEdQB1nS%2BuViQw4k3VGUXntjkDp7aAlqcxdewb/hAc%3D' (2025-06-26)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
