### PR TITLE
Updating flake inputs Mon Jun 30 05:18:44 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1749895289,
-        "narHash": "sha256-b1Hl70p4OOWkcTtXRiJ3Ker9gzOjAoZfwNqxlmE1s7g=",
+        "lastModified": 1751234390,
+        "narHash": "sha256-Q4PLQAooYmYszLx4Uuu85Lbde0jWzsTZAhlmmUL6u+Q=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "e6c755305358412a71a990fc2cf592c629edde1e",
+        "rev": "fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750304462,
-        "narHash": "sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc=",
+        "lastModified": 1751239699,
+        "narHash": "sha256-zA1uUdAq3c26fHm26xMWMuF5COhI18EzaH7az/P2OWM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "863842639722dd12ae9e37ca83bcb61a63b36f6c",
+        "rev": "f6deff178cc4d6049d30785dbfc831e6c6e3a219",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1749958812,
-        "narHash": "sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ=",
+        "lastModified": 1750911390,
+        "narHash": "sha256-1v9yCEDYczPO+NiMvjBcHUrCxpfXyqJDnYjhmBuMlvA=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "6fcfa909614de6dd6c712db8229b8c0261791e39",
+        "rev": "16710e6d4ebc5b1134d5d63e7aa10a8ec8a564cf",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750456174,
-        "narHash": "sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo=",
+        "lastModified": 1751240230,
+        "narHash": "sha256-xAJx/CSglD+qKwag0SzoGZ4+5pw7TxgychgZSS2SPQU=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "0acafb9f533dfc4ca5a43f1341b07ccdb78d5410",
+        "rev": "c064e4d590a1d6fd9109a6fa4cb93434ac2ebbaf",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750325256,
-        "narHash": "sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0=",
+        "lastModified": 1750618568,
+        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9",
+        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749960154,
-        "narHash": "sha256-EWlr9MZDd+GoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg=",
+        "lastModified": 1751170039,
+        "narHash": "sha256-3EKpUmyGmHYA/RuhZjINTZPU+OFWko0eDwazUOW64nw=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "424a40050cdc5f494ec45e46462d288f08c64475",
+        "rev": "9c932ae632d6b5150515e5749b198c175d8565db",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750215678,
-        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
+        "lastModified": 1751180975,
+        "narHash": "sha256-BKk4yDiXr4LdF80OTVqYJ53Q74rOcA/82EClXug8xsY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
+        "rev": "a48741b083d4f36dd79abd9f760c84da6b4dc0e5",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749194973,
-        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "lastModified": 1750931469,
+        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Mon Jun 30 05:18:44 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:doomemacs/doomemacs/fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee' into the Git cache...
unpacking 'github:nix-community/home-manager/f6deff178cc4d6049d30785dbfc831e6c6e3a219' into the Git cache...
unpacking 'github:vic/import-tree/16710e6d4ebc5b1134d5d63e7aa10a8ec8a564cf' into the Git cache...
unpacking 'github:idursun/jjui/c064e4d590a1d6fd9109a6fa4cb93434ac2ebbaf' into the Git cache...
unpacking 'github:LnL7/nix-darwin/1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5' into the Git cache...
unpacking 'github:nix-community/nix-index-database/9c932ae632d6b5150515e5749b198c175d8565db' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/a48741b083d4f36dd79abd9f760c84da6b4dc0e5' into the Git cache...
unpacking 'github:vic/ntv/792d4321b68bb4d707c5342c3bb5b4401165f957' into the Git cache...
unpacking 'github:Mic92/sops-nix/77c423a03b9b2b79709ea2cb63336312e78b72e2' into the Git cache...
unpacking 'github:numtide/treefmt-nix/ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/e6c755305358412a71a990fc2cf592c629edde1e?narHash=sha256-b1Hl70p4OOWkcTtXRiJ3Ker9gzOjAoZfwNqxlmE1s7g%3D' (2025-06-14)
  → 'github:doomemacs/doomemacs/fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee?narHash=sha256-Q4PLQAooYmYszLx4Uuu85Lbde0jWzsTZAhlmmUL6u%2BQ%3D' (2025-06-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/863842639722dd12ae9e37ca83bcb61a63b36f6c?narHash=sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc%3D' (2025-06-19)
  → 'github:nix-community/home-manager/f6deff178cc4d6049d30785dbfc831e6c6e3a219?narHash=sha256-zA1uUdAq3c26fHm26xMWMuF5COhI18EzaH7az/P2OWM%3D' (2025-06-29)
• Updated input 'import-tree':
    'github:vic/import-tree/6fcfa909614de6dd6c712db8229b8c0261791e39?narHash=sha256-zdo2CwxdUK3FpQjLBjkJnXvl7OPoTpjdW5OvOzQffoQ%3D' (2025-06-15)
  → 'github:vic/import-tree/16710e6d4ebc5b1134d5d63e7aa10a8ec8a564cf?narHash=sha256-1v9yCEDYczPO%2BNiMvjBcHUrCxpfXyqJDnYjhmBuMlvA%3D' (2025-06-26)
• Updated input 'jjui':
    'github:idursun/jjui/0acafb9f533dfc4ca5a43f1341b07ccdb78d5410?narHash=sha256-2ziCNxu3ocIeV7tOmm3HEP8v/oMo3SzuO14lebly7oo%3D' (2025-06-20)
  → 'github:idursun/jjui/c064e4d590a1d6fd9109a6fa4cb93434ac2ebbaf?narHash=sha256-xAJx/CSglD%2BqKwag0SzoGZ4%2B5pw7TxgychgZSS2SPQU%3D' (2025-06-29)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9?narHash=sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0%3D' (2025-06-19)
  → 'github:LnL7/nix-darwin/1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5?narHash=sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E%3D' (2025-06-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/424a40050cdc5f494ec45e46462d288f08c64475?narHash=sha256-EWlr9MZDd%2BGoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg%3D' (2025-06-15)
  → 'github:nix-community/nix-index-database/9c932ae632d6b5150515e5749b198c175d8565db?narHash=sha256-3EKpUmyGmHYA/RuhZjINTZPU%2BOFWko0eDwazUOW64nw%3D' (2025-06-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5395fb3ab3f97b9b7abca147249fa2e8ed27b192?narHash=sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M%2Bok%3D' (2025-06-18)
  → 'github:nixos/nixpkgs/a48741b083d4f36dd79abd9f760c84da6b4dc0e5?narHash=sha256-BKk4yDiXr4LdF80OTVqYJ53Q74rOcA/82EClXug8xsY%3D' (2025-06-29)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/a05be418a1af1198ca0f63facb13c985db4cb3c5?narHash=sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk%3D' (2025-06-06)
  → 'github:numtide/treefmt-nix/ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1?narHash=sha256-0IEdQB1nS%2BuViQw4k3VGUXntjkDp7aAlqcxdewb/hAc%3D' (2025-06-26)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
