### PR TITLE
Updating flake inputs Sun Jul  6 05:16:22 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1725138108,
-        "narHash": "sha256-VztTuzCXMvczCzngyZ+tKsi4ak5b0QeTDNlfgmCoRqw=",
+        "lastModified": 1751756323,
+        "narHash": "sha256-yaLcnuX+N3G5YqBo8/kFSsUPhn99119Ba2K5BpqyMKY=",
         "owner": "spikespaz",
         "repo": "allfollow",
-        "rev": "b3caf2b7c13697469e3aebe8205f5035b1e2abd1",
+        "rev": "2e9c241c367f1d33e069d9561d86c160276ab6a9",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1751372926,
-        "narHash": "sha256-K/CRHiYaeemgNFurkmxupRmPFn1r8UNhVZKUT9mVsIc=",
+        "lastModified": 1751746896,
+        "narHash": "sha256-2KFT9v/PGb2K8Vd2eLAhDFQW6ORQapmQmBXipObpkoo=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "6010b40247b8cb4b8a127a34361b99562ea81db9",
+        "rev": "5b5b170f7902e81826fd8efbec88eb38e23e2807",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751589297,
-        "narHash": "sha256-3q35cq6BPuwIRL3IoVKYPc72r3OleeuRyf4YAPjEqzA=",
+        "lastModified": 1751760902,
+        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83f978812c37511ef2ffaf75ffa72160483f738a",
+        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751170039,
-        "narHash": "sha256-3EKpUmyGmHYA/RuhZjINTZPU+OFWko0eDwazUOW64nw=",
+        "lastModified": 1751774635,
+        "narHash": "sha256-DuOznGdgMxeSlPpUu6Wkq0ZD5e2Cfv9XRZeZlHWMd1s=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "9c932ae632d6b5150515e5749b198c175d8565db",
+        "rev": "85686025ba6d18df31cc651a91d5adef63378978",
         "type": "github"
       },
       "original": {
@@ -301,11 +301,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725099143,
-        "narHash": "sha256-CHgumPZaC7z+WYx72WgaLt2XF0yUVzJS60rO4GZ7ytY=",
+        "lastModified": 1751498133,
+        "narHash": "sha256-QWJ+NQbMU+NcU2xiyo7SNox1fAuwksGlQhpzBl76g1I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5629520edecb69630a3f4d17d3d33fc96c13f6fe",
+        "rev": "d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751498133,
-        "narHash": "sha256-QWJ+NQbMU+NcU2xiyo7SNox1fAuwksGlQhpzBl76g1I=",
+        "lastModified": 1751625545,
+        "narHash": "sha256-4E7wWftF1ExK5ZEDzj41+9mVgxtuRV3wWCId7QAYMAU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb",
+        "rev": "c860cf0b3a0829f0f6cf344ca8de83a2bbfab428",
         "type": "github"
       },
       "original": {
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724984647,
-        "narHash": "sha256-BC6MUq0CTdmAu/cueVcdWTI+S95s0mJcn19SoEgd7gU=",
+        "lastModified": 1751596734,
+        "narHash": "sha256-1tQOwmn3jEUQjH0WDJyklC+hR7Bj+iqx6ChtRX2QiPA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "87b6cffc276795b46ef544d7ed8d7fed6ad9c8e4",
+        "rev": "e28ba067a9368286a8bc88b68dc2ca92181a09f0",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751596734,
-        "narHash": "sha256-1tQOwmn3jEUQjH0WDJyklC+hR7Bj+iqx6ChtRX2QiPA=",
+        "lastModified": 1751769931,
+        "narHash": "sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e28ba067a9368286a8bc88b68dc2ca92181a09f0",
+        "rev": "3ac4f630e375177ea8317e22f5c804156de177e8",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750119275,
-        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
+        "lastModified": 1751606940,
+        "narHash": "sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
+        "rev": "3633fc4acf03f43b260244d94c71e9e14a2f6e0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sun Jul  6 05:16:22 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:spikespaz/allfollow/2e9c241c367f1d33e069d9561d86c160276ab6a9' into the Git cache...
unpacking 'github:doomemacs/doomemacs/5b5b170f7902e81826fd8efbec88eb38e23e2807' into the Git cache...
unpacking 'github:nix-community/home-manager/8b0180dde1d6f4cf632e046309e8f963924dfbd0' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/85686025ba6d18df31cc651a91d5adef63378978' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/c860cf0b3a0829f0f6cf344ca8de83a2bbfab428' into the Git cache...
unpacking 'github:oxalica/rust-overlay/3ac4f630e375177ea8317e22f5c804156de177e8' into the Git cache...
unpacking 'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'allfollow':
    'github:spikespaz/allfollow/b3caf2b7c13697469e3aebe8205f5035b1e2abd1?narHash=sha256-VztTuzCXMvczCzngyZ%2BtKsi4ak5b0QeTDNlfgmCoRqw%3D' (2024-08-31)
  → 'github:spikespaz/allfollow/2e9c241c367f1d33e069d9561d86c160276ab6a9?narHash=sha256-yaLcnuX%2BN3G5YqBo8/kFSsUPhn99119Ba2K5BpqyMKY%3D' (2025-07-05)
• Updated input 'allfollow/nixpkgs':
    'github:NixOS/nixpkgs/5629520edecb69630a3f4d17d3d33fc96c13f6fe?narHash=sha256-CHgumPZaC7z%2BWYx72WgaLt2XF0yUVzJS60rO4GZ7ytY%3D' (2024-08-31)
  → 'github:NixOS/nixpkgs/d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb?narHash=sha256-QWJ%2BNQbMU%2BNcU2xiyo7SNox1fAuwksGlQhpzBl76g1I%3D' (2025-07-02)
• Updated input 'allfollow/rust-overlay':
    'github:oxalica/rust-overlay/87b6cffc276795b46ef544d7ed8d7fed6ad9c8e4?narHash=sha256-BC6MUq0CTdmAu/cueVcdWTI%2BS95s0mJcn19SoEgd7gU%3D' (2024-08-30)
  → 'github:oxalica/rust-overlay/e28ba067a9368286a8bc88b68dc2ca92181a09f0?narHash=sha256-1tQOwmn3jEUQjH0WDJyklC%2BhR7Bj%2Biqx6ChtRX2QiPA%3D' (2025-07-04)
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/6010b40247b8cb4b8a127a34361b99562ea81db9?narHash=sha256-K/CRHiYaeemgNFurkmxupRmPFn1r8UNhVZKUT9mVsIc%3D' (2025-07-01)
  → 'github:doomemacs/doomemacs/5b5b170f7902e81826fd8efbec88eb38e23e2807?narHash=sha256-2KFT9v/PGb2K8Vd2eLAhDFQW6ORQapmQmBXipObpkoo%3D' (2025-07-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/83f978812c37511ef2ffaf75ffa72160483f738a?narHash=sha256-3q35cq6BPuwIRL3IoVKYPc72r3OleeuRyf4YAPjEqzA%3D' (2025-07-04)
  → 'github:nix-community/home-manager/8b0180dde1d6f4cf632e046309e8f963924dfbd0?narHash=sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs%3D' (2025-07-06)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/9c932ae632d6b5150515e5749b198c175d8565db?narHash=sha256-3EKpUmyGmHYA/RuhZjINTZPU%2BOFWko0eDwazUOW64nw%3D' (2025-06-29)
  → 'github:nix-community/nix-index-database/85686025ba6d18df31cc651a91d5adef63378978?narHash=sha256-DuOznGdgMxeSlPpUu6Wkq0ZD5e2Cfv9XRZeZlHWMd1s%3D' (2025-07-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb?narHash=sha256-QWJ%2BNQbMU%2BNcU2xiyo7SNox1fAuwksGlQhpzBl76g1I%3D' (2025-07-02)
  → 'github:nixos/nixpkgs/c860cf0b3a0829f0f6cf344ca8de83a2bbfab428?narHash=sha256-4E7wWftF1ExK5ZEDzj41%2B9mVgxtuRV3wWCId7QAYMAU%3D' (2025-07-04)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/e28ba067a9368286a8bc88b68dc2ca92181a09f0?narHash=sha256-1tQOwmn3jEUQjH0WDJyklC%2BhR7Bj%2Biqx6ChtRX2QiPA%3D' (2025-07-04)
  → 'github:oxalica/rust-overlay/3ac4f630e375177ea8317e22f5c804156de177e8?narHash=sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc%3D' (2025-07-06)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/77c423a03b9b2b79709ea2cb63336312e78b72e2?narHash=sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M%3D' (2025-06-17)
  → 'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d?narHash=sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA%3D' (2025-07-04)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
