### PR TITLE
Updating flake inputs Mon Jul  7 05:19:38 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751760902,
-        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
+        "lastModified": 1751824240,
+        "narHash": "sha256-aDDC0CHTlL7QDKWWhdbEgVPK6KwWt+ca0QkmHYZxMzI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
+        "rev": "fd9e55f5fac45a26f6169310afca64d56b681935",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751625545,
-        "narHash": "sha256-4E7wWftF1ExK5ZEDzj41+9mVgxtuRV3wWCId7QAYMAU=",
+        "lastModified": 1751786137,
+        "narHash": "sha256-lIlUKVGCGsh0Q2EA7/6xRtKUZjaQ/ur8uUyY+MynHXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c860cf0b3a0829f0f6cf344ca8de83a2bbfab428",
+        "rev": "ceb24d94c6feaa4e8737a8e2bd3cf71c3a7eaaa0",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751769931,
-        "narHash": "sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc=",
+        "lastModified": 1751856221,
+        "narHash": "sha256-/QE1eV0ckFvgRMcKjZqgdJDoXFNwSMepwRoBjaw2MCk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3ac4f630e375177ea8317e22f5c804156de177e8",
+        "rev": "34cae4b56929c5b340e1c5b10d9a98a425b2a51e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Mon Jul  7 05:19:38 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:spikespaz/allfollow/2e9c241c367f1d33e069d9561d86c160276ab6a9' into the Git cache...
unpacking 'github:doomemacs/doomemacs/5b5b170f7902e81826fd8efbec88eb38e23e2807' into the Git cache...
unpacking 'github:nix-community/home-manager/fd9e55f5fac45a26f6169310afca64d56b681935' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/85686025ba6d18df31cc651a91d5adef63378978' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/ceb24d94c6feaa4e8737a8e2bd3cf71c3a7eaaa0' into the Git cache...
unpacking 'github:oxalica/rust-overlay/34cae4b56929c5b340e1c5b10d9a98a425b2a51e' into the Git cache...
unpacking 'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/8b0180dde1d6f4cf632e046309e8f963924dfbd0?narHash=sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs%3D' (2025-07-06)
  → 'github:nix-community/home-manager/fd9e55f5fac45a26f6169310afca64d56b681935?narHash=sha256-aDDC0CHTlL7QDKWWhdbEgVPK6KwWt%2Bca0QkmHYZxMzI%3D' (2025-07-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c860cf0b3a0829f0f6cf344ca8de83a2bbfab428?narHash=sha256-4E7wWftF1ExK5ZEDzj41%2B9mVgxtuRV3wWCId7QAYMAU%3D' (2025-07-04)
  → 'github:nixos/nixpkgs/ceb24d94c6feaa4e8737a8e2bd3cf71c3a7eaaa0?narHash=sha256-lIlUKVGCGsh0Q2EA7/6xRtKUZjaQ/ur8uUyY%2BMynHXQ%3D' (2025-07-06)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/3ac4f630e375177ea8317e22f5c804156de177e8?narHash=sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc%3D' (2025-07-06)
  → 'github:oxalica/rust-overlay/34cae4b56929c5b340e1c5b10d9a98a425b2a51e?narHash=sha256-/QE1eV0ckFvgRMcKjZqgdJDoXFNwSMepwRoBjaw2MCk%3D' (2025-07-07)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
