### PR TITLE
Updating flake inputs Tue Jul  8 05:17:34 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751756323,
-        "narHash": "sha256-yaLcnuX+N3G5YqBo8/kFSsUPhn99119Ba2K5BpqyMKY=",
+        "lastModified": 1751871122,
+        "narHash": "sha256-UzKNvLDlGxge2TtesS+3YEXVGkiezEEPmbjI7BsOb7s=",
         "owner": "spikespaz",
         "repo": "allfollow",
-        "rev": "2e9c241c367f1d33e069d9561d86c160276ab6a9",
+        "rev": "713d96710dd99fe5f60e2b20e35339481f4542a4",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751760902,
-        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
+        "lastModified": 1751824240,
+        "narHash": "sha256-aDDC0CHTlL7QDKWWhdbEgVPK6KwWt+ca0QkmHYZxMzI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
+        "rev": "fd9e55f5fac45a26f6169310afca64d56b681935",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751625545,
-        "narHash": "sha256-4E7wWftF1ExK5ZEDzj41+9mVgxtuRV3wWCId7QAYMAU=",
+        "lastModified": 1751852175,
+        "narHash": "sha256-+MLlfTCCOvz4K6AcSPbaPiFM9MYi7fA2Wr1ibmRwIlM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c860cf0b3a0829f0f6cf344ca8de83a2bbfab428",
+        "rev": "2defa37146df235ef62f566cde69930a86f14df1",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751769931,
-        "narHash": "sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc=",
+        "lastModified": 1751942411,
+        "narHash": "sha256-01uMHCt2U9tP4f24DGch145tT8YQppLY5TC9mWK7O0A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3ac4f630e375177ea8317e22f5c804156de177e8",
+        "rev": "c587235f892930a61c9e415f0d9792a1b27a41a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Tue Jul  8 05:17:34 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:spikespaz/allfollow/713d96710dd99fe5f60e2b20e35339481f4542a4' into the Git cache...
unpacking 'github:doomemacs/doomemacs/5b5b170f7902e81826fd8efbec88eb38e23e2807' into the Git cache...
unpacking 'github:nix-community/home-manager/fd9e55f5fac45a26f6169310afca64d56b681935' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/85686025ba6d18df31cc651a91d5adef63378978' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09' into the Git cache...
unpacking 'github:nixos/nixpkgs/2defa37146df235ef62f566cde69930a86f14df1' into the Git cache...
unpacking 'github:oxalica/rust-overlay/c587235f892930a61c9e415f0d9792a1b27a41a2' into the Git cache...
unpacking 'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'allfollow':
    'github:spikespaz/allfollow/2e9c241c367f1d33e069d9561d86c160276ab6a9?narHash=sha256-yaLcnuX%2BN3G5YqBo8/kFSsUPhn99119Ba2K5BpqyMKY%3D' (2025-07-05)
  → 'github:spikespaz/allfollow/713d96710dd99fe5f60e2b20e35339481f4542a4?narHash=sha256-UzKNvLDlGxge2TtesS%2B3YEXVGkiezEEPmbjI7BsOb7s%3D' (2025-07-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8b0180dde1d6f4cf632e046309e8f963924dfbd0?narHash=sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs%3D' (2025-07-06)
  → 'github:nix-community/home-manager/fd9e55f5fac45a26f6169310afca64d56b681935?narHash=sha256-aDDC0CHTlL7QDKWWhdbEgVPK6KwWt%2Bca0QkmHYZxMzI%3D' (2025-07-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c860cf0b3a0829f0f6cf344ca8de83a2bbfab428?narHash=sha256-4E7wWftF1ExK5ZEDzj41%2B9mVgxtuRV3wWCId7QAYMAU%3D' (2025-07-04)
  → 'github:nixos/nixpkgs/2defa37146df235ef62f566cde69930a86f14df1?narHash=sha256-%2BMLlfTCCOvz4K6AcSPbaPiFM9MYi7fA2Wr1ibmRwIlM%3D' (2025-07-07)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/3ac4f630e375177ea8317e22f5c804156de177e8?narHash=sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc%3D' (2025-07-06)
  → 'github:oxalica/rust-overlay/c587235f892930a61c9e415f0d9792a1b27a41a2?narHash=sha256-01uMHCt2U9tP4f24DGch145tT8YQppLY5TC9mWK7O0A%3D' (2025-07-08)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
