### PR TITLE
Updating flake inputs Wed Jul  9 05:20:55 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751756323,
-        "narHash": "sha256-yaLcnuX+N3G5YqBo8/kFSsUPhn99119Ba2K5BpqyMKY=",
+        "lastModified": 1751969493,
+        "narHash": "sha256-oA/82ZEAgWyzUUc8PClWt5ry912uScFKMIOC6PFvL6w=",
         "owner": "spikespaz",
         "repo": "allfollow",
-        "rev": "2e9c241c367f1d33e069d9561d86c160276ab6a9",
+        "rev": "cc72dae7a67647ce11a6c4c721c6aadb1a642880",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751760902,
-        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
+        "lastModified": 1751990210,
+        "narHash": "sha256-krWErNDl9ggMLSfK00Q2BcoSk3+IRTSON/DiDgUzzMw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
+        "rev": "218da00bfa73f2a61682417efe74549416c16ba6",
         "type": "github"
       },
       "original": {
@@ -286,11 +286,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749574455,
-        "narHash": "sha256-fm2/8KPOYvvIAnNVtjDlTt/My00lIbZQ+LMrfQIWVzs=",
+        "lastModified": 1752027480,
+        "narHash": "sha256-IkDajRjsCgEpLrTUAlw29aYbRxO1qTqpV9ssMBpXa3g=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "917af390377c573932d84b5e31dd9f2c1b5c0f09",
+        "rev": "d5bf05234f5246294047dd10cb8c6e89cca0e884",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751625545,
-        "narHash": "sha256-4E7wWftF1ExK5ZEDzj41+9mVgxtuRV3wWCId7QAYMAU=",
+        "lastModified": 1751949589,
+        "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c860cf0b3a0829f0f6cf344ca8de83a2bbfab428",
+        "rev": "9b008d60392981ad674e04016d25619281550a9d",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751769931,
-        "narHash": "sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc=",
+        "lastModified": 1752028888,
+        "narHash": "sha256-LRj3/PUpII6taWOrX1w/OeI6f1ncND02PP/kEHvPCqU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3ac4f630e375177ea8317e22f5c804156de177e8",
+        "rev": "a0f1c656e053463b47639234b151a05e4441bb19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Jul  9 05:20:55 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:spikespaz/allfollow/cc72dae7a67647ce11a6c4c721c6aadb1a642880' into the Git cache...
unpacking 'github:doomemacs/doomemacs/5b5b170f7902e81826fd8efbec88eb38e23e2807' into the Git cache...
unpacking 'github:nix-community/home-manager/218da00bfa73f2a61682417efe74549416c16ba6' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/85686025ba6d18df31cc651a91d5adef63378978' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/d5bf05234f5246294047dd10cb8c6e89cca0e884' into the Git cache...
unpacking 'github:nixos/nixpkgs/9b008d60392981ad674e04016d25619281550a9d' into the Git cache...
unpacking 'github:oxalica/rust-overlay/a0f1c656e053463b47639234b151a05e4441bb19' into the Git cache...
unpacking 'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'allfollow':
    'github:spikespaz/allfollow/2e9c241c367f1d33e069d9561d86c160276ab6a9?narHash=sha256-yaLcnuX%2BN3G5YqBo8/kFSsUPhn99119Ba2K5BpqyMKY%3D' (2025-07-05)
  → 'github:spikespaz/allfollow/cc72dae7a67647ce11a6c4c721c6aadb1a642880?narHash=sha256-oA/82ZEAgWyzUUc8PClWt5ry912uScFKMIOC6PFvL6w%3D' (2025-07-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8b0180dde1d6f4cf632e046309e8f963924dfbd0?narHash=sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs%3D' (2025-07-06)
  → 'github:nix-community/home-manager/218da00bfa73f2a61682417efe74549416c16ba6?narHash=sha256-krWErNDl9ggMLSfK00Q2BcoSk3%2BIRTSON/DiDgUzzMw%3D' (2025-07-08)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/917af390377c573932d84b5e31dd9f2c1b5c0f09?narHash=sha256-fm2/8KPOYvvIAnNVtjDlTt/My00lIbZQ%2BLMrfQIWVzs%3D' (2025-06-10)
  → 'github:nix-community/nixos-wsl/d5bf05234f5246294047dd10cb8c6e89cca0e884?narHash=sha256-IkDajRjsCgEpLrTUAlw29aYbRxO1qTqpV9ssMBpXa3g%3D' (2025-07-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c860cf0b3a0829f0f6cf344ca8de83a2bbfab428?narHash=sha256-4E7wWftF1ExK5ZEDzj41%2B9mVgxtuRV3wWCId7QAYMAU%3D' (2025-07-04)
  → 'github:nixos/nixpkgs/9b008d60392981ad674e04016d25619281550a9d?narHash=sha256-mgFxAPLWw0Kq%2BC8P3dRrZrOYEQXOtKuYVlo9xvPntt8%3D' (2025-07-08)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/3ac4f630e375177ea8317e22f5c804156de177e8?narHash=sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc%3D' (2025-07-06)
  → 'github:oxalica/rust-overlay/a0f1c656e053463b47639234b151a05e4441bb19?narHash=sha256-LRj3/PUpII6taWOrX1w/OeI6f1ncND02PP/kEHvPCqU%3D' (2025-07-09)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
