### PR TITLE
Updating flake inputs Sat Jul 12 05:16:54 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752202894,
-        "narHash": "sha256-knafgng4gCjZIUMyAEWjxxdols6n/swkYnbWr+oF+1w=",
+        "lastModified": 1752286566,
+        "narHash": "sha256-A4nftqiNz2bNihz0bKY94Hq/6ydR6UQOcGioeL7iymY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fab659b346c0d4252208434c3c4b3983a4b38fec",
+        "rev": "392ddb642abec771d63688c49fa7bcbb9d2a5717",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752201818,
-        "narHash": "sha256-d8KczaVT8WFEZdWg//tMAbv8EDyn2YTWcJvSY8gqKBU=",
+        "lastModified": 1752288212,
+        "narHash": "sha256-f2PMqtf61mWAM11QoIfGv3hjD2AsJrij4FCzftepuaE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bd8f8329780b348fedcd37b53dbbee48c08c496d",
+        "rev": "678296525a4cce249c608749b171d0b2ceb8b2ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Jul 12 05:16:54 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0' into the Git cache...
unpacking 'github:spikespaz/allfollow/cc72dae7a67647ce11a6c4c721c6aadb1a642880' into the Git cache...
unpacking 'github:doomemacs/doomemacs/5b5b170f7902e81826fd8efbec88eb38e23e2807' into the Git cache...
unpacking 'github:nix-community/home-manager/392ddb642abec771d63688c49fa7bcbb9d2a5717' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/85686025ba6d18df31cc651a91d5adef63378978' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/d34d9412556d3a896e294534ccd25f53b6822e80' into the Git cache...
unpacking 'github:nixos/nixpkgs/9b008d60392981ad674e04016d25619281550a9d' into the Git cache...
unpacking 'github:oxalica/rust-overlay/678296525a4cce249c608749b171d0b2ceb8b2ff' into the Git cache...
unpacking 'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/fab659b346c0d4252208434c3c4b3983a4b38fec?narHash=sha256-knafgng4gCjZIUMyAEWjxxdols6n/swkYnbWr%2BoF%2B1w%3D' (2025-07-11)
  → 'github:nix-community/home-manager/392ddb642abec771d63688c49fa7bcbb9d2a5717?narHash=sha256-A4nftqiNz2bNihz0bKY94Hq/6ydR6UQOcGioeL7iymY%3D' (2025-07-12)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/bd8f8329780b348fedcd37b53dbbee48c08c496d?narHash=sha256-d8KczaVT8WFEZdWg//tMAbv8EDyn2YTWcJvSY8gqKBU%3D' (2025-07-11)
  → 'github:oxalica/rust-overlay/678296525a4cce249c608749b171d0b2ceb8b2ff?narHash=sha256-f2PMqtf61mWAM11QoIfGv3hjD2AsJrij4FCzftepuaE%3D' (2025-07-12)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
