### PR TITLE
Updating flake inputs Wed Jul 16 05:22:40 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741482962,
-        "narHash": "sha256-vCQrmxLw+xgytWR7+cyGdYYV22Jb8iTC9/pbtyJSOX0=",
+        "lastModified": 1752553806,
+        "narHash": "sha256-Mld/3lJ6BHPXSR3tPjby4vBaFMr5RLTVdTmYk4Pkcbw=",
         "owner": "vic",
         "repo": "SPC",
-        "rev": "c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0",
+        "rev": "7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1751600876,
-        "narHash": "sha256-+frHZbR3w6FXe5/Ls41AJHJp1b0aJiUVdS/Hrrhz9Sc=",
+        "lastModified": 1752638477,
+        "narHash": "sha256-7qbQ9Cfch3+91wwjNzhXAudN1BAwftqXNo1Auf7LLok=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "d515758b175bd0dd76901c0d058a9a49038ef81e",
+        "rev": "07bebae2f8be9b3a3aa02296b03456fa3d944a13",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752467539,
-        "narHash": "sha256-4kaR+xmng9YPASckfvIgl5flF/1nAZOplM+Wp9I5SMI=",
+        "lastModified": 1752603129,
+        "narHash": "sha256-S+wmHhwNQ5Ru689L2Gu8n1OD6s9eU9n9mD827JNR+kw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
+        "rev": "e8c19a3cec2814c754f031ab3ae7316b64da085b",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1752171870,
-        "narHash": "sha256-brkC2kw/TnBc6KAu/5vkFctNOUr4FAcsVvbB2v8c+cs=",
+        "lastModified": 1752553522,
+        "narHash": "sha256-YMRSV/VOTUGhCGG+Ynyvub56OXMQrWXtCHkEKmQlZqA=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "ed8a7ece2775278ea967c2427f7bf29d03b864c3",
+        "rev": "26ced5d5e8c2961ac59850969240263fe6198d90",
         "type": "github"
       },
       "original": {
@@ -340,11 +340,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
+        "lastModified": 1751498133,
+        "narHash": "sha256-QWJ+NQbMU+NcU2xiyo7SNox1fAuwksGlQhpzBl76g1I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
+        "rev": "d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb",
         "type": "github"
       },
       "original": {
@@ -371,11 +371,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
+        "lastModified": 1743938762,
+        "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
+        "rev": "74a40410369a1c35ee09b8a1abee6f4acbedc059",
         "type": "github"
       },
       "original": {
@@ -402,11 +402,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
+        "lastModified": 1752596105,
+        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
+        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
+        "lastModified": 1747958103,
+        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
+        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752461263,
-        "narHash": "sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ=",
+        "lastModified": 1751596734,
+        "narHash": "sha256-1tQOwmn3jEUQjH0WDJyklC+hR7Bj+iqx6ChtRX2QiPA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad",
+        "rev": "e28ba067a9368286a8bc88b68dc2ca92181a09f0",
         "type": "github"
       },
       "original": {
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752461263,
-        "narHash": "sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ=",
+        "lastModified": 1752633862,
+        "narHash": "sha256-Bj7ozT1+5P7NmvDcuAXJvj56txcXuAhk3Vd9FdWFQzk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad",
+        "rev": "8668ca94858206ac3db0860a9dec471de0d995f8",
         "type": "github"
       },
       "original": {
@@ -502,11 +502,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751606940,
-        "narHash": "sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA=",
+        "lastModified": 1752544651,
+        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3633fc4acf03f43b260244d94c71e9e14a2f6e0d",
+        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Jul 16 05:22:40 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/cc72dae7a67647ce11a6c4c721c6aadb1a642880' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ed9190ef005829c7a2331e12fb36207794c5ad75' into the Git cache...
unpacking 'github:vic/flake-file/07bebae2f8be9b3a3aa02296b03456fa3d944a13' into the Git cache...
unpacking 'github:nix-community/home-manager/e8c19a3cec2814c754f031ab3ae7316b64da085b' into the Git cache...
unpacking 'github:vic/import-tree/26ced5d5e8c2961ac59850969240263fe6198d90' into the Git cache...
unpacking 'github:vic/jjui/38a10ba7d6b94bf5f081d971342e2be04edbf2ee' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/839e02dece5845be3a322e507a79712b73a96ba2' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/d34d9412556d3a896e294534ccd25f53b6822e80' into the Git cache...
unpacking 'github:nixos/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708' into the Git cache...
unpacking 'github:oxalica/rust-overlay/8668ca94858206ac3db0860a9dec471de0d995f8' into the Git cache...
unpacking 'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'SPC':
    'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0?narHash=sha256-vCQrmxLw%2BxgytWR7%2BcyGdYYV22Jb8iTC9/pbtyJSOX0%3D' (2025-03-09)
  → 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327?narHash=sha256-Mld/3lJ6BHPXSR3tPjby4vBaFMr5RLTVdTmYk4Pkcbw%3D' (2025-07-15)
• Updated input 'allfollow/nixpkgs':
    'github:NixOS/nixpkgs/be9e214982e20b8310878ac2baa063a961c1bdf6?narHash=sha256-HM791ZQtXV93xtCY%2BZxG1REzhQenSQO020cu6rHtAPk%3D' (2025-07-09)
  → 'github:NixOS/nixpkgs/d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb?narHash=sha256-QWJ%2BNQbMU%2BNcU2xiyo7SNox1fAuwksGlQhpzBl76g1I%3D' (2025-07-02)
• Updated input 'allfollow/rust-overlay':
    'github:oxalica/rust-overlay/9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad?narHash=sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ%3D' (2025-07-14)
  → 'github:oxalica/rust-overlay/e28ba067a9368286a8bc88b68dc2ca92181a09f0?narHash=sha256-1tQOwmn3jEUQjH0WDJyklC%2BhR7Bj%2Biqx6ChtRX2QiPA%3D' (2025-07-04)
• Updated input 'flake-file':
    'github:vic/flake-file/d515758b175bd0dd76901c0d058a9a49038ef81e?narHash=sha256-%2BfrHZbR3w6FXe5/Ls41AJHJp1b0aJiUVdS/Hrrhz9Sc%3D' (2025-07-04)
  → 'github:vic/flake-file/07bebae2f8be9b3a3aa02296b03456fa3d944a13?narHash=sha256-7qbQ9Cfch3%2B91wwjNzhXAudN1BAwftqXNo1Auf7LLok%3D' (2025-07-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1e54837569e0b80797c47be4720fab19e0db1616?narHash=sha256-4kaR%2Bxmng9YPASckfvIgl5flF/1nAZOplM%2BWp9I5SMI%3D' (2025-07-14)
  → 'github:nix-community/home-manager/e8c19a3cec2814c754f031ab3ae7316b64da085b?narHash=sha256-S%2BwmHhwNQ5Ru689L2Gu8n1OD6s9eU9n9mD827JNR%2Bkw%3D' (2025-07-15)
• Updated input 'import-tree':
    'github:vic/import-tree/ed8a7ece2775278ea967c2427f7bf29d03b864c3?narHash=sha256-brkC2kw/TnBc6KAu/5vkFctNOUr4FAcsVvbB2v8c%2Bcs%3D' (2025-07-10)
  → 'github:vic/import-tree/26ced5d5e8c2961ac59850969240263fe6198d90?narHash=sha256-YMRSV/VOTUGhCGG%2BYnyvub56OXMQrWXtCHkEKmQlZqA%3D' (2025-07-15)
• Updated input 'jjui/flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
  → 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
• Updated input 'jjui/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/14a40a1d7fb9afa4739275ac642ed7301a9ba1ab?narHash=sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo%3D' (2025-06-29)
  → 'github:nix-community/nixpkgs.lib/e4822aea2a6d1cdd36653c134cacfd64c97ff4fa?narHash=sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc%3D' (2025-03-30)
• Updated input 'jjui/nixpkgs':
    'github:nixos/nixpkgs/be9e214982e20b8310878ac2baa063a961c1bdf6?narHash=sha256-HM791ZQtXV93xtCY%2BZxG1REzhQenSQO020cu6rHtAPk%3D' (2025-07-09)
  → 'github:nixos/nixpkgs/74a40410369a1c35ee09b8a1abee6f4acbedc059?narHash=sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI%3D' (2025-04-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/be9e214982e20b8310878ac2baa063a961c1bdf6?narHash=sha256-HM791ZQtXV93xtCY%2BZxG1REzhQenSQO020cu6rHtAPk%3D' (2025-07-09)
  → 'github:nixos/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad?narHash=sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ%3D' (2025-07-14)
  → 'github:oxalica/rust-overlay/8668ca94858206ac3db0860a9dec471de0d995f8?narHash=sha256-Bj7ozT1%2B5P7NmvDcuAXJvj56txcXuAhk3Vd9FdWFQzk%3D' (2025-07-16)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d?narHash=sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA%3D' (2025-07-04)
  → 'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461?narHash=sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U%3D' (2025-07-15)
• Updated input 'treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/be9e214982e20b8310878ac2baa063a961c1bdf6?narHash=sha256-HM791ZQtXV93xtCY%2BZxG1REzhQenSQO020cu6rHtAPk%3D' (2025-07-09)
  → 'github:nixos/nixpkgs/fe51d34885f7b5e3e7b59572796e1bcb427eccb1?narHash=sha256-qmmFCrfBwSHoWw7cVK4Aj%2Bfns%2Bc54EBP8cGqp/yK410%3D' (2025-05-22)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
