### PR TITLE
Init ssh key before running jjui

### DIFF
--- a/modules/vic/jujutsu.nix
+++ b/modules/vic/jujutsu.nix
@@ -7,11 +7,22 @@
 
   flake.modules.homeManager.vic =
     { pkgs, ... }:
+    let
+      jjui = inputs.jjui.packages.${pkgs.system}.jjui;
+      jjui-wrapped = pkgs.writeShellApplication {
+        name = "jjui";
+        text = ''
+          # ask for password if key is not loaded, before jjui
+          ssh-add -l || ssh-add
+          ${pkgs.lib.getExe jjui} "$@"
+        '';
+      };
+    in
     {
       home.packages = [
         pkgs.lazyjj
         pkgs.jj-fzf
-        inputs.jjui.packages.${pkgs.system}.jjui
+        jjui-wrapped
       ];
 
       programs.jujutsu =


### PR DESCRIPTION
So I don't forget to type my password before jjui runs.

This solves https://github.com/idursun/jjui/issues/100 for me. And prevents jjui from hanging on remote git ops. 