### PR TITLE
Updating flake inputs Thu Jul 31 05:23:58 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1741482962,
-        "narHash": "sha256-vCQrmxLw+xgytWR7+cyGdYYV22Jb8iTC9/pbtyJSOX0=",
+        "lastModified": 1752553806,
+        "narHash": "sha256-Mld/3lJ6BHPXSR3tPjby4vBaFMr5RLTVdTmYk4Pkcbw=",
         "owner": "vic",
         "repo": "SPC",
-        "rev": "c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0",
+        "rev": "7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751969493,
-        "narHash": "sha256-oA/82ZEAgWyzUUc8PClWt5ry912uScFKMIOC6PFvL6w=",
+        "lastModified": 1752903850,
+        "narHash": "sha256-Q9CVcods7Ftcs0KeplhkZOClQKqZy8zwfay02jvNloQ=",
         "owner": "spikespaz",
         "repo": "allfollow",
-        "rev": "cc72dae7a67647ce11a6c4c721c6aadb1a642880",
+        "rev": "5e097ac8c6fb8b9e32a3c590090005abe853cccf",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1752711672,
-        "narHash": "sha256-qgnqQMMIxYRTyIC/lapfPnj4azNUJDG83Ag/+goKpWo=",
+        "lastModified": 1753122811,
+        "narHash": "sha256-D2uccKODLVkI91uiWlwwEkg0X7HcYeiKKGHsD24qmyU=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "01d60df56fda327ce09e1454c861e4b9f96cc814",
+        "rev": "745975d82877699e9504fd0e751b4f70166f066c",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1753121425,
+        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1752467539,
-        "narHash": "sha256-4kaR+xmng9YPASckfvIgl5flF/1nAZOplM+Wp9I5SMI=",
+        "lastModified": 1753888434,
+        "narHash": "sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
+        "rev": "0630790b31d4547d79ff247bc3ba1adda3a017d9",
         "type": "github"
       },
       "original": {
@@ -235,11 +235,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1752171870,
-        "narHash": "sha256-brkC2kw/TnBc6KAu/5vkFctNOUr4FAcsVvbB2v8c+cs=",
+        "lastModified": 1752730890,
+        "narHash": "sha256-GES8fapSLGz36MMPRVNkSUWXUTtqvGQNXHjRmRLfJUY=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "ed8a7ece2775278ea967c2427f7bf29d03b864c3",
+        "rev": "6ebb8cb87987b20264c09296166543fd3761d274",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1752695898,
-        "narHash": "sha256-oM/Pu4Eeuapq1M8R251pm8qav3mZjJQab82nCf+dD0I=",
+        "lastModified": 1753895835,
+        "narHash": "sha256-IwJ8BjMzlH7RZsVE5vM6cW0D+OowuSkfPtXxg+pBCKw=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "defac36a6fe9153f1a9aad35e9bf0050c1e0583a",
+        "rev": "04bec1a2efb54396ba4bf2fb0c58b56bc98394c8",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1752441837,
-        "narHash": "sha256-FMH1OSSJp8Cx8MZHXz6KckxJGbCnVMotZNAH3v2WneU=",
+        "lastModified": 1753589988,
+        "narHash": "sha256-y1JlcMB2dKFkrr6g+Ucmj8L//IY09BtSKTH/A7OU7mU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "839e02dece5845be3a322e507a79712b73a96ba2",
+        "rev": "f0736b09c43028fd726fb70c3eb3d1f0795454cf",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1752199438,
-        "narHash": "sha256-xSBMmGtq8K4Qv80TMqREmESCAsRLJRHAbFH2T/2Bf1Y=",
+        "lastModified": 1753704990,
+        "narHash": "sha256-5E14xuNWy2Un1nFR55k68hgbnD8U2x/rE5DXJtYKusw=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "d34d9412556d3a896e294534ccd25f53b6822e80",
+        "rev": "58c814cc6d4a789191f9c12e18277107144b0c91",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1741310760,
+        "narHash": "sha256-aizILFrPgq/W53Jw8i0a1h1GZAAKtlYOrG/A5r46gVM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "de0fe301211c267807afd11b12613f5511ff7433",
         "type": "github"
       },
       "original": {
@@ -340,21 +340,6 @@
       }
     },
     "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1752369545,
-        "narHash": "sha256-jj/HBJFSapTk4LfeJgNLk2wEE2BO6dgBYVRbXMNOCeM=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "65d21753676aaf55d8e67249138ab1286599a62b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1751159883,
         "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
@@ -369,13 +354,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
         "type": "github"
       },
       "original": {
@@ -387,11 +387,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1747958103,
+        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1682134069,
+        "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "fd901ef4bf93499374c5af385b2943f5801c0833",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1751498133,
+        "narHash": "sha256-QWJ+NQbMU+NcU2xiyo7SNox1fAuwksGlQhpzBl76g1I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1722073938,
+        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1752480373,
-        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
         "type": "github"
       },
       "original": {
@@ -465,11 +465,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1743938762,
+        "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "74a40410369a1c35ee09b8a1abee6f4acbedc059",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1747728033,
+        "narHash": "sha256-NnXFQu7g4LnvPIPfJmBuZF7LFy/fey2g2+LCzjQhTUk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "2f9173bde1d3fbf1ad26ff6d52f952f9e9da52ea",
         "type": "github"
       },
       "original": {
@@ -497,11 +497,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1752480373,
-        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
+        "lastModified": 1753429684,
+        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
+        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1752480373,
-        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
+        "lastModified": 1753429684,
+        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
+        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
+        "lastModified": 1753844155,
+        "narHash": "sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
+        "rev": "e44b8dc0882d66e2627a8ff252b04a22f4a629fd",
         "type": "github"
       },
       "original": {
@@ -575,11 +575,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752461263,
-        "narHash": "sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ=",
+        "lastModified": 1751596734,
+        "narHash": "sha256-1tQOwmn3jEUQjH0WDJyklC+hR7Bj+iqx6ChtRX2QiPA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad",
+        "rev": "e28ba067a9368286a8bc88b68dc2ca92181a09f0",
         "type": "github"
       },
       "original": {
@@ -593,11 +593,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1751606940,
-        "narHash": "sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA=",
+        "lastModified": 1752544651,
+        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3633fc4acf03f43b260244d94c71e9e14a2f6e0d",
+        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
         "type": "github"
       },
       "original": {
@@ -690,11 +690,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752055615,
-        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
         "type": "github"
       },
       "original": {
@@ -708,11 +708,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1752055615,
-        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "lastModified": 1753772294,
+        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
         "type": "github"
       },
       "original": {
@@ -727,11 +727,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1750353031,
-        "narHash": "sha256-Bx7DOPLhkr8Z60U9Qw4l0OidzHoqLDKQH5rDV5ef59A=",
+        "lastModified": 1753541826,
+        "narHash": "sha256-foGgZu8+bCNIGeuDqQ84jNbmKZpd+JvnrL2WlyU4tuU=",
         "owner": "nix-community",
         "repo": "nixos-vscode-server",
-        "rev": "4ec4859b12129c0436b0a471ed1ea6dd8a317993",
+        "rev": "6d5f074e4811d143d44169ba4af09b20ddb6937d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Jul 31 05:23:58 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ed9190ef005829c7a2331e12fb36207794c5ad75' into the Git cache...
unpacking 'github:vic/flake-file/745975d82877699e9504fd0e751b4f70166f066c' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/644e0fc48951a860279da645ba77fe4a6e814c5e' into the Git cache...
unpacking 'github:nix-community/home-manager/0630790b31d4547d79ff247bc3ba1adda3a017d9' into the Git cache...
unpacking 'github:vic/import-tree/6ebb8cb87987b20264c09296166543fd3761d274' into the Git cache...
unpacking 'github:idursun/jjui/04bec1a2efb54396ba4bf2fb0c58b56bc98394c8' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/f0736b09c43028fd726fb70c3eb3d1f0795454cf' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/58c814cc6d4a789191f9c12e18277107144b0c91' into the Git cache...
unpacking 'github:nixos/nixpkgs/e44b8dc0882d66e2627a8ff252b04a22f4a629fd' into the Git cache...
unpacking 'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461' into the Git cache...
unpacking 'github:numtide/treefmt-nix/6b9214fffbcf3f1e608efa15044431651635ca83' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'SPC':
    'github:vic/SPC/c3e65df628fd83580ef43f5c7d5dc1e3f8cdc8a0?narHash=sha256-vCQrmxLw%2BxgytWR7%2BcyGdYYV22Jb8iTC9/pbtyJSOX0%3D' (2025-03-09)
  → 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327?narHash=sha256-Mld/3lJ6BHPXSR3tPjby4vBaFMr5RLTVdTmYk4Pkcbw%3D' (2025-07-15)
• Updated input 'SPC/nixpkgs':
    'github:nixos/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:nixos/nixpkgs/de0fe301211c267807afd11b12613f5511ff7433?narHash=sha256-aizILFrPgq/W53Jw8i0a1h1GZAAKtlYOrG/A5r46gVM%3D' (2025-03-07)
• Updated input 'SPC/treefmt-nix':
    'github:numtide/treefmt-nix/c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9?narHash=sha256-19m7P4O/Aw/6%2BCzncWMAJu89JaKeMh3aMle1CNQSIwM%3D' (2025-07-09)
  → 'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204?narHash=sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU%3D' (2025-02-17)
• Updated input 'allfollow':
    'github:spikespaz/allfollow/cc72dae7a67647ce11a6c4c721c6aadb1a642880?narHash=sha256-oA/82ZEAgWyzUUc8PClWt5ry912uScFKMIOC6PFvL6w%3D' (2025-07-08)
  → 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf?narHash=sha256-Q9CVcods7Ftcs0KeplhkZOClQKqZy8zwfay02jvNloQ%3D' (2025-07-19)
• Updated input 'allfollow/nixpkgs':
    'github:NixOS/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:NixOS/nixpkgs/d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb?narHash=sha256-QWJ%2BNQbMU%2BNcU2xiyo7SNox1fAuwksGlQhpzBl76g1I%3D' (2025-07-02)
• Updated input 'allfollow/rust-overlay':
    'github:oxalica/rust-overlay/9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad?narHash=sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ%3D' (2025-07-14)
  → 'github:oxalica/rust-overlay/e28ba067a9368286a8bc88b68dc2ca92181a09f0?narHash=sha256-1tQOwmn3jEUQjH0WDJyklC%2BhR7Bj%2Biqx6ChtRX2QiPA%3D' (2025-07-04)
• Updated input 'devshell/nixpkgs':
    'github:NixOS/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:NixOS/nixpkgs/e36e9f57337d0ff0cf77aceb58af4c805472bfae?narHash=sha256-OpX0StkL8vpXyWOGUD6G%2BMA26wAXK6SpT94kLJXo6B4%3D' (2024-07-27)
• Updated input 'flake-file':
    'github:vic/flake-file/01d60df56fda327ce09e1454c861e4b9f96cc814?narHash=sha256-qgnqQMMIxYRTyIC/lapfPnj4azNUJDG83Ag/%2BgoKpWo%3D' (2025-07-17)
  → 'github:vic/flake-file/745975d82877699e9504fd0e751b4f70166f066c?narHash=sha256-D2uccKODLVkI91uiWlwwEkg0X7HcYeiKKGHsD24qmyU%3D' (2025-07-21)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
  → 'github:hercules-ci/flake-parts/644e0fc48951a860279da645ba77fe4a6e814c5e?narHash=sha256-TVcTNvOeWWk1DXljFxVRp%2BE0tzG1LhrVjOGGoMHuXio%3D' (2025-07-21)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/65d21753676aaf55d8e67249138ab1286599a62b?narHash=sha256-jj/HBJFSapTk4LfeJgNLk2wEE2BO6dgBYVRbXMNOCeM%3D' (2025-07-13)
  → 'github:nix-community/nixpkgs.lib/14a40a1d7fb9afa4739275ac642ed7301a9ba1ab?narHash=sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo%3D' (2025-06-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1e54837569e0b80797c47be4720fab19e0db1616?narHash=sha256-4kaR%2Bxmng9YPASckfvIgl5flF/1nAZOplM%2BWp9I5SMI%3D' (2025-07-14)
  → 'github:nix-community/home-manager/0630790b31d4547d79ff247bc3ba1adda3a017d9?narHash=sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4%3D' (2025-07-30)
• Updated input 'home-manager/nixpkgs':
    'github:NixOS/nixpkgs/62e0f05ede1da0d54515d4ea8ce9c733f12d9f08?narHash=sha256-JHQbm%2BOcGp32wAsXTE/FLYGNpb%2B4GLi5oTvCxwSoBOA%3D' (2025-07-14)
  → 'github:NixOS/nixpkgs/dc9637876d0dcc8c9e5e22986b857632effeb727?narHash=sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM%3D' (2025-07-28)
• Updated input 'import-tree':
    'github:vic/import-tree/ed8a7ece2775278ea967c2427f7bf29d03b864c3?narHash=sha256-brkC2kw/TnBc6KAu/5vkFctNOUr4FAcsVvbB2v8c%2Bcs%3D' (2025-07-10)
  → 'github:vic/import-tree/6ebb8cb87987b20264c09296166543fd3761d274?narHash=sha256-GES8fapSLGz36MMPRVNkSUWXUTtqvGQNXHjRmRLfJUY%3D' (2025-07-17)
• Updated input 'jjui':
    'github:idursun/jjui/defac36a6fe9153f1a9aad35e9bf0050c1e0583a?narHash=sha256-oM/Pu4Eeuapq1M8R251pm8qav3mZjJQab82nCf%2BdD0I%3D' (2025-07-16)
  → 'github:idursun/jjui/04bec1a2efb54396ba4bf2fb0c58b56bc98394c8?narHash=sha256-IwJ8BjMzlH7RZsVE5vM6cW0D%2BOowuSkfPtXxg%2BpBCKw%3D' (2025-07-30)
• Updated input 'jjui/flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
  → 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
• Updated input 'jjui/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/14a40a1d7fb9afa4739275ac642ed7301a9ba1ab?narHash=sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo%3D' (2025-06-29)
  → 'github:nix-community/nixpkgs.lib/e4822aea2a6d1cdd36653c134cacfd64c97ff4fa?narHash=sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc%3D' (2025-03-30)
• Updated input 'jjui/nixpkgs':
    'github:nixos/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:nixos/nixpkgs/74a40410369a1c35ee09b8a1abee6f4acbedc059?narHash=sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI%3D' (2025-04-06)
• Updated input 'nix-darwin/nixpkgs':
    'github:NixOS/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:NixOS/nixpkgs/2f9173bde1d3fbf1ad26ff6d52f952f9e9da52ea?narHash=sha256-NnXFQu7g4LnvPIPfJmBuZF7LFy/fey2g2%2BLCzjQhTUk%3D' (2025-05-20)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/839e02dece5845be3a322e507a79712b73a96ba2?narHash=sha256-FMH1OSSJp8Cx8MZHXz6KckxJGbCnVMotZNAH3v2WneU%3D' (2025-07-13)
  → 'github:nix-community/nix-index-database/f0736b09c43028fd726fb70c3eb3d1f0795454cf?narHash=sha256-y1JlcMB2dKFkrr6g%2BUcmj8L//IY09BtSKTH/A7OU7mU%3D' (2025-07-27)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/62e0f05ede1da0d54515d4ea8ce9c733f12d9f08?narHash=sha256-JHQbm%2BOcGp32wAsXTE/FLYGNpb%2B4GLi5oTvCxwSoBOA%3D' (2025-07-14)
  → 'github:NixOS/nixpkgs/7fd36ee82c0275fb545775cc5e4d30542899511d?narHash=sha256-9h7%2B4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ%2BSJjk%3D' (2025-07-25)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/d34d9412556d3a896e294534ccd25f53b6822e80?narHash=sha256-xSBMmGtq8K4Qv80TMqREmESCAsRLJRHAbFH2T/2Bf1Y%3D' (2025-07-11)
  → 'github:nix-community/nixos-wsl/58c814cc6d4a789191f9c12e18277107144b0c91?narHash=sha256-5E14xuNWy2Un1nFR55k68hgbnD8U2x/rE5DXJtYKusw%3D' (2025-07-28)
• Updated input 'nixos-wsl/nixpkgs':
    'github:NixOS/nixpkgs/62e0f05ede1da0d54515d4ea8ce9c733f12d9f08?narHash=sha256-JHQbm%2BOcGp32wAsXTE/FLYGNpb%2B4GLi5oTvCxwSoBOA%3D' (2025-07-14)
  → 'github:NixOS/nixpkgs/7fd36ee82c0275fb545775cc5e4d30542899511d?narHash=sha256-9h7%2B4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ%2BSJjk%3D' (2025-07-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/be9e214982e20b8310878ac2baa063a961c1bdf6?narHash=sha256-HM791ZQtXV93xtCY%2BZxG1REzhQenSQO020cu6rHtAPk%3D' (2025-07-09)
  → 'github:nixos/nixpkgs/e44b8dc0882d66e2627a8ff252b04a22f4a629fd?narHash=sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc%3D' (2025-07-30)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/3633fc4acf03f43b260244d94c71e9e14a2f6e0d?narHash=sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA%3D' (2025-07-04)
  → 'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461?narHash=sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U%3D' (2025-07-15)
• Updated input 'sops-nix/nixpkgs':
    'github:NixOS/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:NixOS/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c?narHash=sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs%3D' (2025-04-17)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9?narHash=sha256-19m7P4O/Aw/6%2BCzncWMAJu89JaKeMh3aMle1CNQSIwM%3D' (2025-07-09)
  → 'github:numtide/treefmt-nix/6b9214fffbcf3f1e608efa15044431651635ca83?narHash=sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE%3D' (2025-07-29)
• Updated input 'treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:nixos/nixpkgs/fe51d34885f7b5e3e7b59572796e1bcb427eccb1?narHash=sha256-qmmFCrfBwSHoWw7cVK4Aj%2Bfns%2Bc54EBP8cGqp/yK410%3D' (2025-05-22)
• Updated input 'vscode-server':
    'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993?narHash=sha256-Bx7DOPLhkr8Z60U9Qw4l0OidzHoqLDKQH5rDV5ef59A%3D' (2025-06-19)
  → 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d?narHash=sha256-foGgZu8%2BbCNIGeuDqQ84jNbmKZpd%2BJvnrL2WlyU4tuU%3D' (2025-07-26)
• Updated input 'vscode-server/nixpkgs':
    'github:NixOS/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:NixOS/nixpkgs/fd901ef4bf93499374c5af385b2943f5801c0833?narHash=sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k%3D' (2023-04-22)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
