### PR TITLE
Updating flake inputs Fri Aug  1 05:28:47 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1753888434,
-        "narHash": "sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4=",
+        "lastModified": 1753983724,
+        "narHash": "sha256-2vlAOJv4lBrE+P1uOGhZ1symyjXTRdn/mz0tZ6faQcg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0630790b31d4547d79ff247bc3ba1adda3a017d9",
+        "rev": "7035020a507ed616e2b20c61491ae3eaa8e5462c",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1753895835,
-        "narHash": "sha256-IwJ8BjMzlH7RZsVE5vM6cW0D+OowuSkfPtXxg+pBCKw=",
+        "lastModified": 1753998119,
+        "narHash": "sha256-WvuGQ6cgiviKE3CdmUo87pe64ukGTTx9SbBbzSM1SUY=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "04bec1a2efb54396ba4bf2fb0c58b56bc98394c8",
+        "rev": "f709b54bd1f29d33a26292c33b1d136541c62f71",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1753844155,
-        "narHash": "sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc=",
+        "lastModified": 1753934836,
+        "narHash": "sha256-G06FmIBj0I5bMW1Q8hAEIl5N7IHMK7+Ta4KA+BmneDA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e44b8dc0882d66e2627a8ff252b04a22f4a629fd",
+        "rev": "8679b16e11becd487b45d568358ddf9d5640d860",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Aug  1 05:28:47 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ed9190ef005829c7a2331e12fb36207794c5ad75' into the Git cache...
unpacking 'github:nix-community/home-manager/7035020a507ed616e2b20c61491ae3eaa8e5462c' into the Git cache...
unpacking 'github:idursun/jjui/f709b54bd1f29d33a26292c33b1d136541c62f71' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/f0736b09c43028fd726fb70c3eb3d1f0795454cf' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/58c814cc6d4a789191f9c12e18277107144b0c91' into the Git cache...
unpacking 'github:nixos/nixpkgs/8679b16e11becd487b45d568358ddf9d5640d860' into the Git cache...
unpacking 'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/0630790b31d4547d79ff247bc3ba1adda3a017d9?narHash=sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4%3D' (2025-07-30)
  → 'github:nix-community/home-manager/7035020a507ed616e2b20c61491ae3eaa8e5462c?narHash=sha256-2vlAOJv4lBrE%2BP1uOGhZ1symyjXTRdn/mz0tZ6faQcg%3D' (2025-07-31)
• Updated input 'jjui':
    'github:idursun/jjui/04bec1a2efb54396ba4bf2fb0c58b56bc98394c8?narHash=sha256-IwJ8BjMzlH7RZsVE5vM6cW0D%2BOowuSkfPtXxg%2BpBCKw%3D' (2025-07-30)
  → 'github:idursun/jjui/f709b54bd1f29d33a26292c33b1d136541c62f71?narHash=sha256-WvuGQ6cgiviKE3CdmUo87pe64ukGTTx9SbBbzSM1SUY%3D' (2025-07-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e44b8dc0882d66e2627a8ff252b04a22f4a629fd?narHash=sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc%3D' (2025-07-30)
  → 'github:nixos/nixpkgs/8679b16e11becd487b45d568358ddf9d5640d860?narHash=sha256-G06FmIBj0I5bMW1Q8hAEIl5N7IHMK7%2BTa4KA%2BBmneDA%3D' (2025-07-31)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
