### PR TITLE
Updating flake inputs Sat Aug  2 05:20:50 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1753121425,
-        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "lastModified": 1754091436,
+        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1753888434,
-        "narHash": "sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4=",
+        "lastModified": 1754085240,
+        "narHash": "sha256-kVHCrTWEe8B1thAhFag1bk4QPY0ZP45V9vPbrwPHoNo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0630790b31d4547d79ff247bc3ba1adda3a017d9",
+        "rev": "e102920c1becb114645c6f92fe14edc0b05cc229",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1753895835,
-        "narHash": "sha256-IwJ8BjMzlH7RZsVE5vM6cW0D+OowuSkfPtXxg+pBCKw=",
+        "lastModified": 1754089239,
+        "narHash": "sha256-/jQY1G9cD+tHXPa5USiIkGZWe5Coj06uVwGmaJH4MQg=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "04bec1a2efb54396ba4bf2fb0c58b56bc98394c8",
+        "rev": "ef7bbb817c37d77d18b848f6e5139b93d301dd59",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1753844155,
-        "narHash": "sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc=",
+        "lastModified": 1754060105,
+        "narHash": "sha256-di5L6e5Iiv+oegS07j9h23FdqEpXn0ZQqMlDOEMw1EY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e44b8dc0882d66e2627a8ff252b04a22f4a629fd",
+        "rev": "e7eabdc701d7dbb810fd91a97ec358caa4c1fc50",
         "type": "github"
       },
       "original": {
@@ -708,11 +708,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1753772294,
-        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
+        "lastModified": 1754061284,
+        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
+        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Aug  2 05:20:50 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ed9190ef005829c7a2331e12fb36207794c5ad75' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/67df8c627c2c39c41dbec76a1f201929929ab0bd' into the Git cache...
unpacking 'github:nix-community/home-manager/e102920c1becb114645c6f92fe14edc0b05cc229' into the Git cache...
unpacking 'github:idursun/jjui/ef7bbb817c37d77d18b848f6e5139b93d301dd59' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/f0736b09c43028fd726fb70c3eb3d1f0795454cf' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/58c814cc6d4a789191f9c12e18277107144b0c91' into the Git cache...
unpacking 'github:nixos/nixpkgs/e7eabdc701d7dbb810fd91a97ec358caa4c1fc50' into the Git cache...
unpacking 'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461' into the Git cache...
unpacking 'github:numtide/treefmt-nix/58bd4da459f0a39e506847109a2a5cfceb837796' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/644e0fc48951a860279da645ba77fe4a6e814c5e?narHash=sha256-TVcTNvOeWWk1DXljFxVRp%2BE0tzG1LhrVjOGGoMHuXio%3D' (2025-07-21)
  → 'github:hercules-ci/flake-parts/67df8c627c2c39c41dbec76a1f201929929ab0bd?narHash=sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM%3D' (2025-08-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/14a40a1d7fb9afa4739275ac642ed7301a9ba1ab?narHash=sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo%3D' (2025-06-29)
  → 'github:nix-community/nixpkgs.lib/0f36c44e01a6129be94e3ade315a5883f0228a6e?narHash=sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA%3D' (2025-07-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0630790b31d4547d79ff247bc3ba1adda3a017d9?narHash=sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4%3D' (2025-07-30)
  → 'github:nix-community/home-manager/e102920c1becb114645c6f92fe14edc0b05cc229?narHash=sha256-kVHCrTWEe8B1thAhFag1bk4QPY0ZP45V9vPbrwPHoNo%3D' (2025-08-01)
• Updated input 'jjui':
    'github:idursun/jjui/04bec1a2efb54396ba4bf2fb0c58b56bc98394c8?narHash=sha256-IwJ8BjMzlH7RZsVE5vM6cW0D%2BOowuSkfPtXxg%2BpBCKw%3D' (2025-07-30)
  → 'github:idursun/jjui/ef7bbb817c37d77d18b848f6e5139b93d301dd59?narHash=sha256-/jQY1G9cD%2BtHXPa5USiIkGZWe5Coj06uVwGmaJH4MQg%3D' (2025-08-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e44b8dc0882d66e2627a8ff252b04a22f4a629fd?narHash=sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc%3D' (2025-07-30)
  → 'github:nixos/nixpkgs/e7eabdc701d7dbb810fd91a97ec358caa4c1fc50?narHash=sha256-di5L6e5Iiv%2BoegS07j9h23FdqEpXn0ZQqMlDOEMw1EY%3D' (2025-08-01)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/6b9214fffbcf3f1e608efa15044431651635ca83?narHash=sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE%3D' (2025-07-29)
  → 'github:numtide/treefmt-nix/58bd4da459f0a39e506847109a2a5cfceb837796?narHash=sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU%3D' (2025-08-01)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
