### PR TITLE
Updating flake inputs Fri Aug  8 05:25:51 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754091436,
-        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1754174776,
-        "narHash": "sha256-Sp3FRM6xNwNtGzYH/HByjzJYHSQvwsW+lDMMZNF43PQ=",
+        "lastModified": 1754613544,
+        "narHash": "sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1+cc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445",
+        "rev": "cc2fa2331aebf9661d22bb507d362b39852ac73f",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1754151399,
-        "narHash": "sha256-rr6N2MQ60SE9WV/Mah7iaO+GAHLEoJiuuc0RnNg8INg=",
+        "lastModified": 1754334398,
+        "narHash": "sha256-XWsHkfakSVQZtmN21exUc62is6qT3jw/1FF9RNaW0Uo=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "ddb31f855c7d8d384b2dae7405edc2dccd51eac4",
+        "rev": "19dbec6fa7b85efa017d6329510b7ff2b6471c2c",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1753704990,
-        "narHash": "sha256-5E14xuNWy2Un1nFR55k68hgbnD8U2x/rE5DXJtYKusw=",
+        "lastModified": 1754326498,
+        "narHash": "sha256-3ynDaygIzQYlBZFHGDeQzXmPkX2ILeZ0wWJ84FR4g7E=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "58c814cc6d4a789191f9c12e18277107144b0c91",
+        "rev": "ca55236cd9ef3cdea29b51a0b52a9402c60e9a27",
         "type": "github"
       },
       "original": {
@@ -387,11 +387,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1753694789,
-        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1753429684,
-        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1754151594,
-        "narHash": "sha256-S30TWshtDmNlU30u842RidFUraKj1f2dd4nrKRHm3gE=",
+        "lastModified": 1754393734,
+        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7b6929d8b900de3142638310f8bc40cff4f2c507",
+        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
         "type": "github"
       },
       "original": {
@@ -593,11 +593,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1752544651,
-        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
+        "lastModified": 1754328224,
+        "narHash": "sha256-glPK8DF329/dXtosV7YSzRlF4n35WDjaVwdOMEoEXHA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
+        "rev": "49021900e69812ba7ddb9e40f9170218a7eca9f4",
         "type": "github"
       },
       "original": {
@@ -708,11 +708,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1754061284,
-        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Aug  8 05:25:51 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/ed9190ef005829c7a2331e12fb36207794c5ad75' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18' into the Git cache...
unpacking 'github:nix-community/home-manager/cc2fa2331aebf9661d22bb507d362b39852ac73f' into the Git cache...
unpacking 'github:idursun/jjui/19dbec6fa7b85efa017d6329510b7ff2b6471c2c' into the Git cache...
unpacking 'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf' into the Git cache...
unpacking 'github:nix-community/nix-index-database/b7fcd4e26d67fca48e77de9b0d0f954b18ae9562' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/ca55236cd9ef3cdea29b51a0b52a9402c60e9a27' into the Git cache...
unpacking 'github:nixos/nixpkgs/a683adc19ff5228af548c6539dbc3440509bfed3' into the Git cache...
unpacking 'github:Mic92/sops-nix/49021900e69812ba7ddb9e40f9170218a7eca9f4' into the Git cache...
unpacking 'github:numtide/treefmt-nix/1298185c05a56bff66383a20be0b41a307f52228' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/67df8c627c2c39c41dbec76a1f201929929ab0bd?narHash=sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM%3D' (2025-08-01)
  → 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445?narHash=sha256-Sp3FRM6xNwNtGzYH/HByjzJYHSQvwsW%2BlDMMZNF43PQ%3D' (2025-08-02)
  → 'github:nix-community/home-manager/cc2fa2331aebf9661d22bb507d362b39852ac73f?narHash=sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1%2Bcc%3D' (2025-08-08)
• Updated input 'home-manager/nixpkgs':
    'github:NixOS/nixpkgs/dc9637876d0dcc8c9e5e22986b857632effeb727?narHash=sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM%3D' (2025-07-28)
  → 'github:NixOS/nixpkgs/5b09dc45f24cf32316283e62aec81ffee3c3e376?narHash=sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY%3D' (2025-08-03)
• Updated input 'jjui':
    'github:idursun/jjui/ddb31f855c7d8d384b2dae7405edc2dccd51eac4?narHash=sha256-rr6N2MQ60SE9WV/Mah7iaO%2BGAHLEoJiuuc0RnNg8INg%3D' (2025-08-02)
  → 'github:idursun/jjui/19dbec6fa7b85efa017d6329510b7ff2b6471c2c?narHash=sha256-XWsHkfakSVQZtmN21exUc62is6qT3jw/1FF9RNaW0Uo%3D' (2025-08-04)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/58c814cc6d4a789191f9c12e18277107144b0c91?narHash=sha256-5E14xuNWy2Un1nFR55k68hgbnD8U2x/rE5DXJtYKusw%3D' (2025-07-28)
  → 'github:nix-community/nixos-wsl/ca55236cd9ef3cdea29b51a0b52a9402c60e9a27?narHash=sha256-3ynDaygIzQYlBZFHGDeQzXmPkX2ILeZ0wWJ84FR4g7E%3D' (2025-08-04)
• Updated input 'nixos-wsl/nixpkgs':
    'github:NixOS/nixpkgs/7fd36ee82c0275fb545775cc5e4d30542899511d?narHash=sha256-9h7%2B4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ%2BSJjk%3D' (2025-07-25)
  → 'github:NixOS/nixpkgs/5b09dc45f24cf32316283e62aec81ffee3c3e376?narHash=sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY%3D' (2025-08-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7b6929d8b900de3142638310f8bc40cff4f2c507?narHash=sha256-S30TWshtDmNlU30u842RidFUraKj1f2dd4nrKRHm3gE%3D' (2025-08-02)
  → 'github:nixos/nixpkgs/a683adc19ff5228af548c6539dbc3440509bfed3?narHash=sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak%3D' (2025-08-05)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461?narHash=sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U%3D' (2025-07-15)
  → 'github:Mic92/sops-nix/49021900e69812ba7ddb9e40f9170218a7eca9f4?narHash=sha256-glPK8DF329/dXtosV7YSzRlF4n35WDjaVwdOMEoEXHA%3D' (2025-08-04)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/58bd4da459f0a39e506847109a2a5cfceb837796?narHash=sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU%3D' (2025-08-01)
  → 'github:numtide/treefmt-nix/1298185c05a56bff66383a20be0b41a307f52228?narHash=sha256-B%2B3g9%2B76KlGe34Yk9za8AF3RL%2BlnbHXkLiVHLjYVOAc%3D' (2025-08-06)
• Updated input 'treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/fe51d34885f7b5e3e7b59572796e1bcb427eccb1?narHash=sha256-qmmFCrfBwSHoWw7cVK4Aj%2Bfns%2Bc54EBP8cGqp/yK410%3D' (2025-05-22)
  → 'github:nixos/nixpkgs/cab778239e705082fe97bb4990e0d24c50924c04?narHash=sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU%3D' (2025-08-04)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
