### PR TITLE
Updating flake inputs Fri Aug 29 05:14:52 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1752438514,
-        "narHash": "sha256-nU/UmyYQAcPHGJEC1mVm40LY3LlA7df9khckbvMB5x8=",
+        "lastModified": 1756305047,
+        "narHash": "sha256-JdFKV52EMCf3fLJRNIxd5gO/BMG2cTYCwng9yz2nPKU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ed9190ef005829c7a2331e12fb36207794c5ad75",
+        "rev": "058cb20a12e29cc1990b0c08b887873689bc968f",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754091436,
-        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1754174776,
-        "narHash": "sha256-Sp3FRM6xNwNtGzYH/HByjzJYHSQvwsW+lDMMZNF43PQ=",
+        "lastModified": 1756261190,
+        "narHash": "sha256-eiy0klFK5EVJLNilutR7grsZN/7Itj9DyD75eyOf83k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445",
+        "rev": "77f348da3176dc68b20a73dab94852a417daf361",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1754151399,
-        "narHash": "sha256-rr6N2MQ60SE9WV/Mah7iaO+GAHLEoJiuuc0RnNg8INg=",
+        "lastModified": 1755988557,
+        "narHash": "sha256-PD0hW60W733+1DrCwGf51qbsbZGk3BBN96GdZf15PgE=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "ddb31f855c7d8d384b2dae7405edc2dccd51eac4",
+        "rev": "9e2b5d4832be6c9a93c0c514a7fa0d4ea5cc728e",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1751313918,
-        "narHash": "sha256-HsJM3XLa43WpG+665aGEh8iS8AfEwOIQWk3Mke3e7nk=",
+        "lastModified": 1755825449,
+        "narHash": "sha256-XkiN4NM9Xdy59h69Pc+Vg4PxkSm9EWl6u7k6D5FZ5cM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e04a388232d9a6ba56967ce5b53a8a6f713cdfcf",
+        "rev": "8df64f819698c1fee0c2969696f54a843b2231e8",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1754195341,
-        "narHash": "sha256-YL71IEf2OugH3gmAsxQox6BJI0KOcHKtW2QqT/+s2SA=",
+        "lastModified": 1756008611,
+        "narHash": "sha256-rfTBWuTXi9/X7GhtF562FKNXKh2kvKb6dwI5lV1SjPE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b7fcd4e26d67fca48e77de9b0d0f954b18ae9562",
+        "rev": "52dec1cb33a614accb9e01307e17816be974d24d",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1753704990,
-        "narHash": "sha256-5E14xuNWy2Un1nFR55k68hgbnD8U2x/rE5DXJtYKusw=",
+        "lastModified": 1755261305,
+        "narHash": "sha256-EOqCupB5X5WoGVHVcfOZcqy0SbKWNuY3kq+lj1wHdu8=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "58c814cc6d4a789191f9c12e18277107144b0c91",
+        "rev": "203a7b463f307c60026136dd1191d9001c43457f",
         "type": "github"
       },
       "original": {
@@ -387,11 +387,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1753694789,
-        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -497,11 +497,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1753939845,
-        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1753429684,
-        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1754151594,
-        "narHash": "sha256-S30TWshtDmNlU30u842RidFUraKj1f2dd4nrKRHm3gE=",
+        "lastModified": 1756381814,
+        "narHash": "sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu+aKRQdHk7sIyoia4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7b6929d8b900de3142638310f8bc40cff4f2c507",
+        "rev": "aca2499b79170038df0dbaec8bf2f689b506ad32",
         "type": "github"
       },
       "original": {
@@ -593,11 +593,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1752544651,
-        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
+        "lastModified": 1754988908,
+        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
+        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
         "type": "github"
       },
       "original": {
@@ -708,11 +708,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1754061284,
-        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
+        "lastModified": 1755934250,
+        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
+        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Aug 29 05:14:52 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/058cb20a12e29cc1990b0c08b887873689bc968f' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18' into the Git cache...
unpacking 'github:nix-community/home-manager/77f348da3176dc68b20a73dab94852a417daf361' into the Git cache...
unpacking 'github:idursun/jjui/9e2b5d4832be6c9a93c0c514a7fa0d4ea5cc728e' into the Git cache...
unpacking 'github:LnL7/nix-darwin/8df64f819698c1fee0c2969696f54a843b2231e8' into the Git cache...
unpacking 'github:nix-community/nix-index-database/52dec1cb33a614accb9e01307e17816be974d24d' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/203a7b463f307c60026136dd1191d9001c43457f' into the Git cache...
unpacking 'github:nixos/nixpkgs/aca2499b79170038df0dbaec8bf2f689b506ad32' into the Git cache...
unpacking 'github:Mic92/sops-nix/3223c7a92724b5d804e9988c6b447a0d09017d48' into the Git cache...
unpacking 'github:numtide/treefmt-nix/74e1a52d5bd9430312f8d1b8b0354c92c17453e5' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/ed9190ef005829c7a2331e12fb36207794c5ad75?narHash=sha256-nU/UmyYQAcPHGJEC1mVm40LY3LlA7df9khckbvMB5x8%3D' (2025-07-13)
  → 'github:doomemacs/doomemacs/058cb20a12e29cc1990b0c08b887873689bc968f?narHash=sha256-JdFKV52EMCf3fLJRNIxd5gO/BMG2cTYCwng9yz2nPKU%3D' (2025-08-27)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/67df8c627c2c39c41dbec76a1f201929929ab0bd?narHash=sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM%3D' (2025-08-01)
  → 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445?narHash=sha256-Sp3FRM6xNwNtGzYH/HByjzJYHSQvwsW%2BlDMMZNF43PQ%3D' (2025-08-02)
  → 'github:nix-community/home-manager/77f348da3176dc68b20a73dab94852a417daf361?narHash=sha256-eiy0klFK5EVJLNilutR7grsZN/7Itj9DyD75eyOf83k%3D' (2025-08-27)
• Updated input 'home-manager/nixpkgs':
    'github:NixOS/nixpkgs/dc9637876d0dcc8c9e5e22986b857632effeb727?narHash=sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM%3D' (2025-07-28)
  → 'github:NixOS/nixpkgs/20075955deac2583bb12f07151c2df830ef346b4?narHash=sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs%2BStOp19xNsbqdOg%3D' (2025-08-19)
• Updated input 'jjui':
    'github:idursun/jjui/ddb31f855c7d8d384b2dae7405edc2dccd51eac4?narHash=sha256-rr6N2MQ60SE9WV/Mah7iaO%2BGAHLEoJiuuc0RnNg8INg%3D' (2025-08-02)
  → 'github:idursun/jjui/9e2b5d4832be6c9a93c0c514a7fa0d4ea5cc728e?narHash=sha256-PD0hW60W733%2B1DrCwGf51qbsbZGk3BBN96GdZf15PgE%3D' (2025-08-23)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf?narHash=sha256-HsJM3XLa43WpG%2B665aGEh8iS8AfEwOIQWk3Mke3e7nk%3D' (2025-06-30)
  → 'github:LnL7/nix-darwin/8df64f819698c1fee0c2969696f54a843b2231e8?narHash=sha256-XkiN4NM9Xdy59h69Pc%2BVg4PxkSm9EWl6u7k6D5FZ5cM%3D' (2025-08-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b7fcd4e26d67fca48e77de9b0d0f954b18ae9562?narHash=sha256-YL71IEf2OugH3gmAsxQox6BJI0KOcHKtW2QqT/%2Bs2SA%3D' (2025-08-03)
  → 'github:nix-community/nix-index-database/52dec1cb33a614accb9e01307e17816be974d24d?narHash=sha256-rfTBWuTXi9/X7GhtF562FKNXKh2kvKb6dwI5lV1SjPE%3D' (2025-08-24)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/94def634a20494ee057c76998843c015909d6311?narHash=sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1%2BA4GQej/lBk5y7I%3D' (2025-07-31)
  → 'github:NixOS/nixpkgs/20075955deac2583bb12f07151c2df830ef346b4?narHash=sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs%2BStOp19xNsbqdOg%3D' (2025-08-19)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/58c814cc6d4a789191f9c12e18277107144b0c91?narHash=sha256-5E14xuNWy2Un1nFR55k68hgbnD8U2x/rE5DXJtYKusw%3D' (2025-07-28)
  → 'github:nix-community/nixos-wsl/203a7b463f307c60026136dd1191d9001c43457f?narHash=sha256-EOqCupB5X5WoGVHVcfOZcqy0SbKWNuY3kq%2Blj1wHdu8%3D' (2025-08-15)
• Updated input 'nixos-wsl/nixpkgs':
    'github:NixOS/nixpkgs/7fd36ee82c0275fb545775cc5e4d30542899511d?narHash=sha256-9h7%2B4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ%2BSJjk%3D' (2025-07-25)
  → 'github:NixOS/nixpkgs/85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054?narHash=sha256-iAcj9T/Y%2B3DBy2J0N%2ByF9XQQQ8IEb5swLFzs23CdP88%3D' (2025-08-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7b6929d8b900de3142638310f8bc40cff4f2c507?narHash=sha256-S30TWshtDmNlU30u842RidFUraKj1f2dd4nrKRHm3gE%3D' (2025-08-02)
  → 'github:nixos/nixpkgs/aca2499b79170038df0dbaec8bf2f689b506ad32?narHash=sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu%2BaKRQdHk7sIyoia4%3D' (2025-08-28)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/2c8def626f54708a9c38a5861866660395bb3461?narHash=sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U%3D' (2025-07-15)
  → 'github:Mic92/sops-nix/3223c7a92724b5d804e9988c6b447a0d09017d48?narHash=sha256-t%2Bvoe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U%3D' (2025-08-12)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/58bd4da459f0a39e506847109a2a5cfceb837796?narHash=sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU%3D' (2025-08-01)
  → 'github:numtide/treefmt-nix/74e1a52d5bd9430312f8d1b8b0354c92c17453e5?narHash=sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU%3D' (2025-08-23)
• Updated input 'treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/fe51d34885f7b5e3e7b59572796e1bcb427eccb1?narHash=sha256-qmmFCrfBwSHoWw7cVK4Aj%2Bfns%2Bc54EBP8cGqp/yK410%3D' (2025-05-22)
  → 'github:nixos/nixpkgs/cab778239e705082fe97bb4990e0d24c50924c04?narHash=sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU%3D' (2025-08-04)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
