### PR TITLE
Updating flake inputs Sat Aug 30 05:13:43 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1756305047,
-        "narHash": "sha256-JdFKV52EMCf3fLJRNIxd5gO/BMG2cTYCwng9yz2nPKU=",
+        "lastModified": 1756507740,
+        "narHash": "sha256-TvDOQ3mHLvzwUmy/NuE1lkJWmPdkwsIbFPO8OOqOIFI=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "058cb20a12e29cc1990b0c08b887873689bc968f",
+        "rev": "b1826a0c6469f57b377b08ef7d54005504b12d59",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756261190,
-        "narHash": "sha256-eiy0klFK5EVJLNilutR7grsZN/7Itj9DyD75eyOf83k=",
+        "lastModified": 1756496801,
+        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77f348da3176dc68b20a73dab94852a417daf361",
+        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1755988557,
-        "narHash": "sha256-PD0hW60W733+1DrCwGf51qbsbZGk3BBN96GdZf15PgE=",
+        "lastModified": 1756496215,
+        "narHash": "sha256-I21wq8mCHbqbD4ctodqs3Lwk2d+yADudk22e0UBqRmk=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "9e2b5d4832be6c9a93c0c514a7fa0d4ea5cc728e",
+        "rev": "88147c7a7d17c63fa86ae7c89dd4f9f515952776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Aug 30 05:13:43 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/b1826a0c6469f57b377b08ef7d54005504b12d59' into the Git cache...
unpacking 'github:nix-community/home-manager/77a71380c38fb2a440b4b5881bbc839f6230e1cb' into the Git cache...
unpacking 'github:idursun/jjui/88147c7a7d17c63fa86ae7c89dd4f9f515952776' into the Git cache...
unpacking 'github:LnL7/nix-darwin/8df64f819698c1fee0c2969696f54a843b2231e8' into the Git cache...
unpacking 'github:nix-community/nix-index-database/52dec1cb33a614accb9e01307e17816be974d24d' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/203a7b463f307c60026136dd1191d9001c43457f' into the Git cache...
unpacking 'github:nixos/nixpkgs/aca2499b79170038df0dbaec8bf2f689b506ad32' into the Git cache...
unpacking 'github:Mic92/sops-nix/3223c7a92724b5d804e9988c6b447a0d09017d48' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/058cb20a12e29cc1990b0c08b887873689bc968f?narHash=sha256-JdFKV52EMCf3fLJRNIxd5gO/BMG2cTYCwng9yz2nPKU%3D' (2025-08-27)
  → 'github:doomemacs/doomemacs/b1826a0c6469f57b377b08ef7d54005504b12d59?narHash=sha256-TvDOQ3mHLvzwUmy/NuE1lkJWmPdkwsIbFPO8OOqOIFI%3D' (2025-08-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/77f348da3176dc68b20a73dab94852a417daf361?narHash=sha256-eiy0klFK5EVJLNilutR7grsZN/7Itj9DyD75eyOf83k%3D' (2025-08-27)
  → 'github:nix-community/home-manager/77a71380c38fb2a440b4b5881bbc839f6230e1cb?narHash=sha256-IYIsnPy%2BcJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8%3D' (2025-08-29)
• Updated input 'jjui':
    'github:idursun/jjui/9e2b5d4832be6c9a93c0c514a7fa0d4ea5cc728e?narHash=sha256-PD0hW60W733%2B1DrCwGf51qbsbZGk3BBN96GdZf15PgE%3D' (2025-08-23)
  → 'github:idursun/jjui/88147c7a7d17c63fa86ae7c89dd4f9f515952776?narHash=sha256-I21wq8mCHbqbD4ctodqs3Lwk2d%2ByADudk22e0UBqRmk%3D' (2025-08-29)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
