### PR TITLE
Updating flake inputs Thu Sep 11 05:15:24 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1756507740,
-        "narHash": "sha256-TvDOQ3mHLvzwUmy/NuE1lkJWmPdkwsIbFPO8OOqOIFI=",
+        "lastModified": 1757106921,
+        "narHash": "sha256-vHwgENjip2+AFzs4oZfnKEAJKwf5Zid7fakImvxxQUw=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "b1826a0c6469f57b377b08ef7d54005504b12d59",
+        "rev": "8f55404781edacf66fa330205533b002de3fb5ee",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1753122811,
-        "narHash": "sha256-D2uccKODLVkI91uiWlwwEkg0X7HcYeiKKGHsD24qmyU=",
+        "lastModified": 1756540347,
+        "narHash": "sha256-O306WrpZF8o7bNwx3fYZu5Qu6vHsS9k6rx01+e6ALwQ=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "745975d82877699e9504fd0e751b4f70166f066c",
+        "rev": "c04f95b47c8e6a3c961f88f068dbb3d3caad3ad1",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756496801,
-        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
+        "lastModified": 1757529548,
+        "narHash": "sha256-If5AT3dPXH0BM+q+pwyZvtWLTmlqJmGW6IDZ2MqlGRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
+        "rev": "e0154ae41614e32a443c43ee51eee9eed3ad9a48",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1756496215,
-        "narHash": "sha256-I21wq8mCHbqbD4ctodqs3Lwk2d+yADudk22e0UBqRmk=",
+        "lastModified": 1757159876,
+        "narHash": "sha256-AQ2jhqN8nTy8xOFb6ztAFezS2CJYqE8lZu2R4nNYfaE=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "88147c7a7d17c63fa86ae7c89dd4f9f515952776",
+        "rev": "a3c62ceb96ca974e286b32207bb8c741bb172b3a",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1755825449,
-        "narHash": "sha256-XkiN4NM9Xdy59h69Pc+Vg4PxkSm9EWl6u7k6D5FZ5cM=",
+        "lastModified": 1757430124,
+        "narHash": "sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8df64f819698c1fee0c2969696f54a843b2231e8",
+        "rev": "830b3f0b50045cf0bcfd4dab65fad05bf882e196",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1756008611,
-        "narHash": "sha256-rfTBWuTXi9/X7GhtF562FKNXKh2kvKb6dwI5lV1SjPE=",
+        "lastModified": 1757218147,
+        "narHash": "sha256-IwOwN70HvoBNB2ckaROxcaCvj5NudNc52taPsv5wtLk=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "52dec1cb33a614accb9e01307e17816be974d24d",
+        "rev": "9b144dc3ef6e42b888c4190e02746aab13b0e97f",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755261305,
-        "narHash": "sha256-EOqCupB5X5WoGVHVcfOZcqy0SbKWNuY3kq+lj1wHdu8=",
+        "lastModified": 1757427959,
+        "narHash": "sha256-p0i07rLfAMzJWYfsjFOXEtIWeS1EGVxJaCi9gfyCwRE=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "203a7b463f307c60026136dd1191d9001c43457f",
+        "rev": "785f1b67b6c53de088f640f2a7da50ca4b2d7161",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -371,11 +371,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1757347588,
+        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
         "type": "github"
       },
       "original": {
@@ -497,11 +497,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1754725699,
-        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1756381814,
-        "narHash": "sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu+aKRQdHk7sIyoia4=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aca2499b79170038df0dbaec8bf2f689b506ad32",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -593,11 +593,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1754988908,
-        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
+        "lastModified": 1757503115,
+        "narHash": "sha256-S9F6bHUBh+CFEUalv/qxNImRapCxvSnOzWBUZgK1zDU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
+        "rev": "0bf793823386187dff101ee2a9d4ed26de8bbf8c",
         "type": "github"
       },
       "original": {
@@ -708,11 +708,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1755934250,
-        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Thu Sep 11 05:15:24 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/8f55404781edacf66fa330205533b002de3fb5ee' into the Git cache...
unpacking 'github:vic/flake-file/c04f95b47c8e6a3c961f88f068dbb3d3caad3ad1' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751' into the Git cache...
unpacking 'github:nix-community/home-manager/e0154ae41614e32a443c43ee51eee9eed3ad9a48' into the Git cache...
unpacking 'github:idursun/jjui/a3c62ceb96ca974e286b32207bb8c741bb172b3a' into the Git cache...
unpacking 'github:LnL7/nix-darwin/830b3f0b50045cf0bcfd4dab65fad05bf882e196' into the Git cache...
unpacking 'github:nix-community/nix-index-database/9b144dc3ef6e42b888c4190e02746aab13b0e97f' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/785f1b67b6c53de088f640f2a7da50ca4b2d7161' into the Git cache...
unpacking 'github:nixos/nixpkgs/ca77296380960cd497a765102eeb1356eb80fed0' into the Git cache...
unpacking 'github:Mic92/sops-nix/0bf793823386187dff101ee2a9d4ed26de8bbf8c' into the Git cache...
unpacking 'github:numtide/treefmt-nix/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/b1826a0c6469f57b377b08ef7d54005504b12d59?narHash=sha256-TvDOQ3mHLvzwUmy/NuE1lkJWmPdkwsIbFPO8OOqOIFI%3D' (2025-08-29)
  → 'github:doomemacs/doomemacs/8f55404781edacf66fa330205533b002de3fb5ee?narHash=sha256-vHwgENjip2%2BAFzs4oZfnKEAJKwf5Zid7fakImvxxQUw%3D' (2025-09-05)
• Updated input 'flake-file':
    'github:vic/flake-file/745975d82877699e9504fd0e751b4f70166f066c?narHash=sha256-D2uccKODLVkI91uiWlwwEkg0X7HcYeiKKGHsD24qmyU%3D' (2025-07-21)
  → 'github:vic/flake-file/c04f95b47c8e6a3c961f88f068dbb3d3caad3ad1?narHash=sha256-O306WrpZF8o7bNwx3fYZu5Qu6vHsS9k6rx01%2Be6ALwQ%3D' (2025-08-30)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
  → 'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751?narHash=sha256-%2BuWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw%3D' (2025-09-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/0f36c44e01a6129be94e3ade315a5883f0228a6e?narHash=sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA%3D' (2025-07-27)
  → 'github:nix-community/nixpkgs.lib/a73b9c743612e4244d865a2fdee11865283c04e6?narHash=sha256-x2rJ%2BOvzq0sCMpgfgGaaqgBSwY%2BLST%2BWbZ6TytnT9Rk%3D' (2025-08-10)
• Updated input 'home-manager':
    'github:nix-community/home-manager/77a71380c38fb2a440b4b5881bbc839f6230e1cb?narHash=sha256-IYIsnPy%2BcJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8%3D' (2025-08-29)
  → 'github:nix-community/home-manager/e0154ae41614e32a443c43ee51eee9eed3ad9a48?narHash=sha256-If5AT3dPXH0BM%2Bq%2BpwyZvtWLTmlqJmGW6IDZ2MqlGRU%3D' (2025-09-10)
• Updated input 'home-manager/nixpkgs':
    'github:NixOS/nixpkgs/20075955deac2583bb12f07151c2df830ef346b4?narHash=sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs%2BStOp19xNsbqdOg%3D' (2025-08-19)
  → 'github:NixOS/nixpkgs/b599843bad24621dcaa5ab60dac98f9b0eb1cabe?narHash=sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL%2Bnma8o%3D' (2025-09-08)
• Updated input 'jjui':
    'github:idursun/jjui/88147c7a7d17c63fa86ae7c89dd4f9f515952776?narHash=sha256-I21wq8mCHbqbD4ctodqs3Lwk2d%2ByADudk22e0UBqRmk%3D' (2025-08-29)
  → 'github:idursun/jjui/a3c62ceb96ca974e286b32207bb8c741bb172b3a?narHash=sha256-AQ2jhqN8nTy8xOFb6ztAFezS2CJYqE8lZu2R4nNYfaE%3D' (2025-09-06)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/8df64f819698c1fee0c2969696f54a843b2231e8?narHash=sha256-XkiN4NM9Xdy59h69Pc%2BVg4PxkSm9EWl6u7k6D5FZ5cM%3D' (2025-08-22)
  → 'github:LnL7/nix-darwin/830b3f0b50045cf0bcfd4dab65fad05bf882e196?narHash=sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk%3D' (2025-09-09)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/52dec1cb33a614accb9e01307e17816be974d24d?narHash=sha256-rfTBWuTXi9/X7GhtF562FKNXKh2kvKb6dwI5lV1SjPE%3D' (2025-08-24)
  → 'github:nix-community/nix-index-database/9b144dc3ef6e42b888c4190e02746aab13b0e97f?narHash=sha256-IwOwN70HvoBNB2ckaROxcaCvj5NudNc52taPsv5wtLk%3D' (2025-09-07)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/20075955deac2583bb12f07151c2df830ef346b4?narHash=sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs%2BStOp19xNsbqdOg%3D' (2025-08-19)
  → 'github:NixOS/nixpkgs/8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9?narHash=sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4%3D' (2025-09-05)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/203a7b463f307c60026136dd1191d9001c43457f?narHash=sha256-EOqCupB5X5WoGVHVcfOZcqy0SbKWNuY3kq%2Blj1wHdu8%3D' (2025-08-15)
  → 'github:nix-community/nixos-wsl/785f1b67b6c53de088f640f2a7da50ca4b2d7161?narHash=sha256-p0i07rLfAMzJWYfsjFOXEtIWeS1EGVxJaCi9gfyCwRE%3D' (2025-09-09)
• Updated input 'nixos-wsl/nixpkgs':
    'github:NixOS/nixpkgs/85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054?narHash=sha256-iAcj9T/Y%2B3DBy2J0N%2ByF9XQQQ8IEb5swLFzs23CdP88%3D' (2025-08-09)
  → 'github:NixOS/nixpkgs/8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9?narHash=sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4%3D' (2025-09-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/aca2499b79170038df0dbaec8bf2f689b506ad32?narHash=sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu%2BaKRQdHk7sIyoia4%3D' (2025-08-28)
  → 'github:nixos/nixpkgs/ca77296380960cd497a765102eeb1356eb80fed0?narHash=sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao%3D' (2025-09-05)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/3223c7a92724b5d804e9988c6b447a0d09017d48?narHash=sha256-t%2Bvoe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U%3D' (2025-08-12)
  → 'github:Mic92/sops-nix/0bf793823386187dff101ee2a9d4ed26de8bbf8c?narHash=sha256-S9F6bHUBh%2BCFEUalv/qxNImRapCxvSnOzWBUZgK1zDU%3D' (2025-09-10)
• Updated input 'sops-nix/nixpkgs':
    'github:NixOS/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c?narHash=sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs%3D' (2025-04-17)
  → 'github:NixOS/nixpkgs/ca77296380960cd497a765102eeb1356eb80fed0?narHash=sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao%3D' (2025-09-05)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/74e1a52d5bd9430312f8d1b8b0354c92c17453e5?narHash=sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU%3D' (2025-08-23)
  → 'github:numtide/treefmt-nix/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4?narHash=sha256-F1oFfV51AE259I85av%2BMAia221XwMHCOtZCMcZLK2Jk%3D' (2025-08-31)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
