### PR TITLE
Updating flake inputs Wed Sep 17 05:15:10 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1757976811,
-        "narHash": "sha256-kZx3fwrRatN+yRT4qvG2ehMOqvtClnv2M2fzrlRRDiI=",
+        "lastModified": 1758035022,
+        "narHash": "sha256-shOYc1WnSuHXFDzHbMaB/m3WST0QhV/MjEfvbJIl+9o=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "e10477d6d1f1cd8c9369daad6b74f7d2e6e9fad9",
+        "rev": "6a270b64d57fc49e4f9ef8f491ff719b2fc0a78d",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757997814,
-        "narHash": "sha256-F+1aoG+3NH4jDDEmhnDUReISyq6kQBBuktTUqCUWSiw=",
+        "lastModified": 1758085625,
+        "narHash": "sha256-D0KVKNgWSDVjYFgPLEtSQvSKchTBT0YqSbNlH7OQ+bo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5820376beb804de9acf07debaaff1ac84728b708",
+        "rev": "fb928abb67bd4df99040721ed48c3b42e24b1d08",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1757159876,
-        "narHash": "sha256-AQ2jhqN8nTy8xOFb6ztAFezS2CJYqE8lZu2R4nNYfaE=",
+        "lastModified": 1758057366,
+        "narHash": "sha256-5m3IcOCunnHtukQ/dQ6y17fZYJ4faODLPITSulSMKMg=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "a3c62ceb96ca974e286b32207bb8c741bb172b3a",
+        "rev": "c3ff49bf51948e438e60030e0f8fd4c2fcd91f1d",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1757935978,
-        "narHash": "sha256-xeHiYTqlibGf6VQADGrZ2GzayTOJo8G0g8D8f5zCE3Y=",
+        "lastModified": 1758029226,
+        "narHash": "sha256-TjqVmbpoCqWywY9xIZLTf6ANFvDCXdctCjoYuYPYdMI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0b96957fb614f693d0cee1bd65fbfc0e610df47f",
+        "rev": "08b8f92ac6354983f5382124fef6006cade4a1c1",
         "type": "github"
       },
       "original": {
@@ -610,11 +610,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1757847158,
-        "narHash": "sha256-TumOaykhZO8SOs/faz6GQhqkOcFLoQvESLSF1cJ4mZc=",
+        "lastModified": 1758007585,
+        "narHash": "sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ee6f91c1c11acf7957d94a130de77561ec24b8ab",
+        "rev": "f77d4cfa075c3de66fc9976b80e0c4fc69e2c139",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Sep 17 05:15:10 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/6a270b64d57fc49e4f9ef8f491ff719b2fc0a78d' into the Git cache...
unpacking 'github:mudler/edgevpn/45ace51385b5aad01ad8712853c90d559a339ee4' into the Git cache...
unpacking 'github:nix-community/home-manager/fb928abb67bd4df99040721ed48c3b42e24b1d08' into the Git cache...
unpacking 'github:idursun/jjui/c3ff49bf51948e438e60030e0f8fd4c2fcd91f1d' into the Git cache...
unpacking 'github:LnL7/nix-darwin/830b3f0b50045cf0bcfd4dab65fad05bf882e196' into the Git cache...
unpacking 'github:nix-community/nix-index-database/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/134e117c969f42277f1c5e60c8fbcac103c2c454' into the Git cache...
unpacking 'github:nixos/nixpkgs/08b8f92ac6354983f5382124fef6006cade4a1c1' into the Git cache...
unpacking 'github:Mic92/sops-nix/f77d4cfa075c3de66fc9976b80e0c4fc69e2c139' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/e10477d6d1f1cd8c9369daad6b74f7d2e6e9fad9?narHash=sha256-kZx3fwrRatN%2ByRT4qvG2ehMOqvtClnv2M2fzrlRRDiI%3D' (2025-09-15)
  → 'github:doomemacs/doomemacs/6a270b64d57fc49e4f9ef8f491ff719b2fc0a78d?narHash=sha256-shOYc1WnSuHXFDzHbMaB/m3WST0QhV/MjEfvbJIl%2B9o%3D' (2025-09-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5820376beb804de9acf07debaaff1ac84728b708?narHash=sha256-F%2B1aoG%2B3NH4jDDEmhnDUReISyq6kQBBuktTUqCUWSiw%3D' (2025-09-16)
  → 'github:nix-community/home-manager/fb928abb67bd4df99040721ed48c3b42e24b1d08?narHash=sha256-D0KVKNgWSDVjYFgPLEtSQvSKchTBT0YqSbNlH7OQ%2Bbo%3D' (2025-09-17)
• Updated input 'jjui':
    'github:idursun/jjui/a3c62ceb96ca974e286b32207bb8c741bb172b3a?narHash=sha256-AQ2jhqN8nTy8xOFb6ztAFezS2CJYqE8lZu2R4nNYfaE%3D' (2025-09-06)
  → 'github:idursun/jjui/c3ff49bf51948e438e60030e0f8fd4c2fcd91f1d?narHash=sha256-5m3IcOCunnHtukQ/dQ6y17fZYJ4faODLPITSulSMKMg%3D' (2025-09-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0b96957fb614f693d0cee1bd65fbfc0e610df47f?narHash=sha256-xeHiYTqlibGf6VQADGrZ2GzayTOJo8G0g8D8f5zCE3Y%3D' (2025-09-15)
  → 'github:nixos/nixpkgs/08b8f92ac6354983f5382124fef6006cade4a1c1?narHash=sha256-TjqVmbpoCqWywY9xIZLTf6ANFvDCXdctCjoYuYPYdMI%3D' (2025-09-16)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/ee6f91c1c11acf7957d94a130de77561ec24b8ab?narHash=sha256-TumOaykhZO8SOs/faz6GQhqkOcFLoQvESLSF1cJ4mZc%3D' (2025-09-14)
  → 'github:Mic92/sops-nix/f77d4cfa075c3de66fc9976b80e0c4fc69e2c139?narHash=sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c%3D' (2025-09-16)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
