### PR TITLE
Updating flake inputs Sat Sep 20 05:13:44 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1757976811,
-        "narHash": "sha256-kZx3fwrRatN+yRT4qvG2ehMOqvtClnv2M2fzrlRRDiI=",
+        "lastModified": 1758296187,
+        "narHash": "sha256-rbdKF2wGHEK29pXohXU69qccx4yI4i2iLS15b72KakQ=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "e10477d6d1f1cd8c9369daad6b74f7d2e6e9fad9",
+        "rev": "6ea4332b854d311d7ec8ae6384fae8d9871f5730",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757997814,
-        "narHash": "sha256-F+1aoG+3NH4jDDEmhnDUReISyq6kQBBuktTUqCUWSiw=",
+        "lastModified": 1758296614,
+        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5820376beb804de9acf07debaaff1ac84728b708",
+        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1757159876,
-        "narHash": "sha256-AQ2jhqN8nTy8xOFb6ztAFezS2CJYqE8lZu2R4nNYfaE=",
+        "lastModified": 1758209717,
+        "narHash": "sha256-8aIgm7FnIIvrLTUuyKyGk7vVUASm+BYYMem3R0FugU8=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "a3c62ceb96ca974e286b32207bb8c741bb172b3a",
+        "rev": "03011dd5754166d3c1184b6b1ae4e635c3cdcf12",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1757430124,
-        "narHash": "sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk=",
+        "lastModified": 1758102940,
+        "narHash": "sha256-wwqf3+A8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "830b3f0b50045cf0bcfd4dab65fad05bf882e196",
+        "rev": "ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd",
         "type": "github"
       },
       "original": {
@@ -326,11 +326,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757937573,
-        "narHash": "sha256-B+MT526k5th4x22h213/CgzdkKWIaeaa0+Y0uuCkH/I=",
+        "lastModified": 1758123407,
+        "narHash": "sha256-4qwMlR0Q4Zr2rjUFauYIldfjzffYt3G5tZ1uPFPPYGU=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "134e117c969f42277f1c5e60c8fbcac103c2c454",
+        "rev": "ba2b3b6c0bc42442559a3b090f032bc8d501f5e3",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1757935978,
-        "narHash": "sha256-xeHiYTqlibGf6VQADGrZ2GzayTOJo8G0g8D8f5zCE3Y=",
+        "lastModified": 1758262103,
+        "narHash": "sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0b96957fb614f693d0cee1bd65fbfc0e610df47f",
+        "rev": "12bd230118a1901a4a5d393f9f56b6ad7e571d01",
         "type": "github"
       },
       "original": {
@@ -610,11 +610,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1757847158,
-        "narHash": "sha256-TumOaykhZO8SOs/faz6GQhqkOcFLoQvESLSF1cJ4mZc=",
+        "lastModified": 1758007585,
+        "narHash": "sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ee6f91c1c11acf7957d94a130de77561ec24b8ab",
+        "rev": "f77d4cfa075c3de66fc9976b80e0c4fc69e2c139",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1756662192,
-        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
+        "lastModified": 1758206697,
+        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
+        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Sat Sep 20 05:13:44 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/6ea4332b854d311d7ec8ae6384fae8d9871f5730' into the Git cache...
unpacking 'github:mudler/edgevpn/45ace51385b5aad01ad8712853c90d559a339ee4' into the Git cache...
unpacking 'github:nix-community/home-manager/55b1f5b7b191572257545413b98e37abab2fdb00' into the Git cache...
unpacking 'github:idursun/jjui/03011dd5754166d3c1184b6b1ae4e635c3cdcf12' into the Git cache...
unpacking 'github:LnL7/nix-darwin/ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd' into the Git cache...
unpacking 'github:nix-community/nix-index-database/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/ba2b3b6c0bc42442559a3b090f032bc8d501f5e3' into the Git cache...
unpacking 'github:nixos/nixpkgs/12bd230118a1901a4a5d393f9f56b6ad7e571d01' into the Git cache...
unpacking 'github:Mic92/sops-nix/f77d4cfa075c3de66fc9976b80e0c4fc69e2c139' into the Git cache...
unpacking 'github:numtide/treefmt-nix/128222dc911b8e2e18939537bed1762b7f3a04aa' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/e10477d6d1f1cd8c9369daad6b74f7d2e6e9fad9?narHash=sha256-kZx3fwrRatN%2ByRT4qvG2ehMOqvtClnv2M2fzrlRRDiI%3D' (2025-09-15)
  → 'github:doomemacs/doomemacs/6ea4332b854d311d7ec8ae6384fae8d9871f5730?narHash=sha256-rbdKF2wGHEK29pXohXU69qccx4yI4i2iLS15b72KakQ%3D' (2025-09-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5820376beb804de9acf07debaaff1ac84728b708?narHash=sha256-F%2B1aoG%2B3NH4jDDEmhnDUReISyq6kQBBuktTUqCUWSiw%3D' (2025-09-16)
  → 'github:nix-community/home-manager/55b1f5b7b191572257545413b98e37abab2fdb00?narHash=sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY%2Bq0kQ%3D' (2025-09-19)
• Updated input 'jjui':
    'github:idursun/jjui/a3c62ceb96ca974e286b32207bb8c741bb172b3a?narHash=sha256-AQ2jhqN8nTy8xOFb6ztAFezS2CJYqE8lZu2R4nNYfaE%3D' (2025-09-06)
  → 'github:idursun/jjui/03011dd5754166d3c1184b6b1ae4e635c3cdcf12?narHash=sha256-8aIgm7FnIIvrLTUuyKyGk7vVUASm%2BBYYMem3R0FugU8%3D' (2025-09-18)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/830b3f0b50045cf0bcfd4dab65fad05bf882e196?narHash=sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk%3D' (2025-09-09)
  → 'github:LnL7/nix-darwin/ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd?narHash=sha256-wwqf3%2BA8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o%3D' (2025-09-17)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/134e117c969f42277f1c5e60c8fbcac103c2c454?narHash=sha256-B%2BMT526k5th4x22h213/CgzdkKWIaeaa0%2BY0uuCkH/I%3D' (2025-09-15)
  → 'github:nix-community/nixos-wsl/ba2b3b6c0bc42442559a3b090f032bc8d501f5e3?narHash=sha256-4qwMlR0Q4Zr2rjUFauYIldfjzffYt3G5tZ1uPFPPYGU%3D' (2025-09-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0b96957fb614f693d0cee1bd65fbfc0e610df47f?narHash=sha256-xeHiYTqlibGf6VQADGrZ2GzayTOJo8G0g8D8f5zCE3Y%3D' (2025-09-15)
  → 'github:nixos/nixpkgs/12bd230118a1901a4a5d393f9f56b6ad7e571d01?narHash=sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8%3D' (2025-09-19)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/ee6f91c1c11acf7957d94a130de77561ec24b8ab?narHash=sha256-TumOaykhZO8SOs/faz6GQhqkOcFLoQvESLSF1cJ4mZc%3D' (2025-09-14)
  → 'github:Mic92/sops-nix/f77d4cfa075c3de66fc9976b80e0c4fc69e2c139?narHash=sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c%3D' (2025-09-16)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4?narHash=sha256-F1oFfV51AE259I85av%2BMAia221XwMHCOtZCMcZLK2Jk%3D' (2025-08-31)
  → 'github:numtide/treefmt-nix/128222dc911b8e2e18939537bed1762b7f3a04aa?narHash=sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0%3D' (2025-09-18)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
