### PR TITLE
Updating flake inputs Wed Oct  1 05:15:29 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1758296187,
-        "narHash": "sha256-rbdKF2wGHEK29pXohXU69qccx4yI4i2iLS15b72KakQ=",
+        "lastModified": 1759180402,
+        "narHash": "sha256-Y67ooUjDMWjPk+/IjMRnhe+OPn19Q0wF73prtExwyiI=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "6ea4332b854d311d7ec8ae6384fae8d9871f5730",
+        "rev": "5e7e93beb9f2b5a81768aaf4950203ceea21c4f6",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1758296614,
-        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
+        "lastModified": 1759261733,
+        "narHash": "sha256-G104PUPKBgJmcu4NWs0LUaPpSOTD4jiq4mamLWu3Oc0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
+        "rev": "5a21f4819ee1be645f46d6b255d49f4271ef6723",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1758209717,
-        "narHash": "sha256-8aIgm7FnIIvrLTUuyKyGk7vVUASm+BYYMem3R0FugU8=",
+        "lastModified": 1758969410,
+        "narHash": "sha256-uCE+sP8eFZgcyJp8sNpPwT5iUEVXEaFVMNuZrRQIKnA=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "03011dd5754166d3c1184b6b1ae4e635c3cdcf12",
+        "rev": "c99f5b11fc1ac7660dc94b6bdbdca9cb126cf017",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1758102940,
-        "narHash": "sha256-wwqf3+A8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o=",
+        "lastModified": 1758805352,
+        "narHash": "sha256-BHdc43Lkayd+72W/NXRKHzX5AZ+28F3xaUs3a88/Uew=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd",
+        "rev": "c48e963a5558eb1c3827d59d21c5193622a1477c",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1757822619,
-        "narHash": "sha256-3HIpe3P2h1AUPYcAH9cjuX0tZOqJpX01c0iDwoUYNZ8=",
+        "lastModified": 1759032422,
+        "narHash": "sha256-WZf+FhebP2/1pK2np5xj/NuDjD6fXK2BHnq/tPUN18o=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea",
+        "rev": "ec7a78cb0e098832d8acac091a4df393259c4839",
         "type": "github"
       },
       "original": {
@@ -326,11 +326,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758123407,
-        "narHash": "sha256-4qwMlR0Q4Zr2rjUFauYIldfjzffYt3G5tZ1uPFPPYGU=",
+        "lastModified": 1758785683,
+        "narHash": "sha256-mRn51IeEBXeNh5a6xNLylk4PKBX0s/QQxgkEbYoPq/w=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "ba2b3b6c0bc42442559a3b090f032bc8d501f5e3",
+        "rev": "1bfb978f2f6261b6086e04af17f9418e1fe36d70",
         "type": "github"
       },
       "original": {
@@ -387,11 +387,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1757746433,
-        "narHash": "sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn+odUBTaindgiziY=",
+        "lastModified": 1758976413,
+        "narHash": "sha256-hEIDTaIqvW1NMfaNgz6pjhZPZKTmACJmXxGr/H6isIg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6d7ec06d6868ac6d94c371458fc2391ded9ff13d",
+        "rev": "e3a3b32cc234f1683258d36c6232f150d57df015",
         "type": "github"
       },
       "original": {
@@ -465,11 +465,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1758262103,
-        "narHash": "sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8=",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "12bd230118a1901a4a5d393f9f56b6ad7e571d01",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
@@ -610,11 +610,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1758007585,
-        "narHash": "sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c=",
+        "lastModified": 1759188042,
+        "narHash": "sha256-f9QC2KKiNReZDG2yyKAtDZh0rSK2Xp1wkPzKbHeQVRU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f77d4cfa075c3de66fc9976b80e0c4fc69e2c139",
+        "rev": "9fcfabe085281dd793589bdc770a2e577a3caa5d",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1758206697,
-        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
+        "lastModified": 1758728421,
+        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
+        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Wed Oct  1 05:15:29 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/5e7e93beb9f2b5a81768aaf4950203ceea21c4f6' into the Git cache...
unpacking 'github:mudler/edgevpn/45ace51385b5aad01ad8712853c90d559a339ee4' into the Git cache...
unpacking 'github:nix-community/home-manager/5a21f4819ee1be645f46d6b255d49f4271ef6723' into the Git cache...
unpacking 'github:idursun/jjui/c99f5b11fc1ac7660dc94b6bdbdca9cb126cf017' into the Git cache...
unpacking 'github:LnL7/nix-darwin/c48e963a5558eb1c3827d59d21c5193622a1477c' into the Git cache...
unpacking 'github:nix-community/nix-index-database/ec7a78cb0e098832d8acac091a4df393259c4839' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/1bfb978f2f6261b6086e04af17f9418e1fe36d70' into the Git cache...
unpacking 'github:nixos/nixpkgs/647e5c14cbd5067f44ac86b74f014962df460840' into the Git cache...
unpacking 'github:Mic92/sops-nix/9fcfabe085281dd793589bdc770a2e577a3caa5d' into the Git cache...
unpacking 'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/6ea4332b854d311d7ec8ae6384fae8d9871f5730?narHash=sha256-rbdKF2wGHEK29pXohXU69qccx4yI4i2iLS15b72KakQ%3D' (2025-09-19)
  → 'github:doomemacs/doomemacs/5e7e93beb9f2b5a81768aaf4950203ceea21c4f6?narHash=sha256-Y67ooUjDMWjPk%2B/IjMRnhe%2BOPn19Q0wF73prtExwyiI%3D' (2025-09-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/55b1f5b7b191572257545413b98e37abab2fdb00?narHash=sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY%2Bq0kQ%3D' (2025-09-19)
  → 'github:nix-community/home-manager/5a21f4819ee1be645f46d6b255d49f4271ef6723?narHash=sha256-G104PUPKBgJmcu4NWs0LUaPpSOTD4jiq4mamLWu3Oc0%3D' (2025-09-30)
• Updated input 'home-manager/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1?narHash=sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/e643668fd71b949c53f8626614b21ff71a07379d?narHash=sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o%3D' (2025-09-24)
• Updated input 'jjui':
    'github:idursun/jjui/03011dd5754166d3c1184b6b1ae4e635c3cdcf12?narHash=sha256-8aIgm7FnIIvrLTUuyKyGk7vVUASm%2BBYYMem3R0FugU8%3D' (2025-09-18)
  → 'github:idursun/jjui/c99f5b11fc1ac7660dc94b6bdbdca9cb126cf017?narHash=sha256-uCE%2BsP8eFZgcyJp8sNpPwT5iUEVXEaFVMNuZrRQIKnA%3D' (2025-09-27)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd?narHash=sha256-wwqf3%2BA8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o%3D' (2025-09-17)
  → 'github:LnL7/nix-darwin/c48e963a5558eb1c3827d59d21c5193622a1477c?narHash=sha256-BHdc43Lkayd%2B72W/NXRKHzX5AZ%2B28F3xaUs3a88/Uew%3D' (2025-09-25)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea?narHash=sha256-3HIpe3P2h1AUPYcAH9cjuX0tZOqJpX01c0iDwoUYNZ8%3D' (2025-09-14)
  → 'github:nix-community/nix-index-database/ec7a78cb0e098832d8acac091a4df393259c4839?narHash=sha256-WZf%2BFhebP2/1pK2np5xj/NuDjD6fXK2BHnq/tPUN18o%3D' (2025-09-28)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1?narHash=sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/e643668fd71b949c53f8626614b21ff71a07379d?narHash=sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o%3D' (2025-09-24)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/ba2b3b6c0bc42442559a3b090f032bc8d501f5e3?narHash=sha256-4qwMlR0Q4Zr2rjUFauYIldfjzffYt3G5tZ1uPFPPYGU%3D' (2025-09-17)
  → 'github:nix-community/nixos-wsl/1bfb978f2f6261b6086e04af17f9418e1fe36d70?narHash=sha256-mRn51IeEBXeNh5a6xNLylk4PKBX0s/QQxgkEbYoPq/w%3D' (2025-09-25)
• Updated input 'nixos-wsl/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1?narHash=sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/8eaee110344796db060382e15d3af0a9fc396e0e?narHash=sha256-iCGWf/LTy%2BaY0zFu8q12lK8KuZp7yvdhStehhyX1v8w%3D' (2025-09-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/12bd230118a1901a4a5d393f9f56b6ad7e571d01?narHash=sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8%3D' (2025-09-19)
  → 'github:nixos/nixpkgs/647e5c14cbd5067f44ac86b74f014962df460840?narHash=sha256-JVZl8NaVRYb0%2B381nl7LvPE%2BA774/dRpif01FKLrYFQ%3D' (2025-09-28)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f77d4cfa075c3de66fc9976b80e0c4fc69e2c139?narHash=sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c%3D' (2025-09-16)
  → 'github:Mic92/sops-nix/9fcfabe085281dd793589bdc770a2e577a3caa5d?narHash=sha256-f9QC2KKiNReZDG2yyKAtDZh0rSK2Xp1wkPzKbHeQVRU%3D' (2025-09-29)
• Updated input 'sops-nix/nixpkgs':
    'github:NixOS/nixpkgs/6d7ec06d6868ac6d94c371458fc2391ded9ff13d?narHash=sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn%2BodUBTaindgiziY%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/e3a3b32cc234f1683258d36c6232f150d57df015?narHash=sha256-hEIDTaIqvW1NMfaNgz6pjhZPZKTmACJmXxGr/H6isIg%3D' (2025-09-27)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/128222dc911b8e2e18939537bed1762b7f3a04aa?narHash=sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0%3D' (2025-09-18)
  → 'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1?narHash=sha256-ySNJ008muQAds2JemiyrWYbwbG%2BV7S5wg3ZVKGHSFu8%3D' (2025-09-24)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
