### PR TITLE
Updating flake inputs Fri Oct 24 05:15:48 UTC 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1758296187,
-        "narHash": "sha256-rbdKF2wGHEK29pXohXU69qccx4yI4i2iLS15b72KakQ=",
+        "lastModified": 1760602791,
+        "narHash": "sha256-voIvrHMgs2zFNtYDxVnyBpmSCE3NFZAhhcZsUneDMLw=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "6ea4332b854d311d7ec8ae6384fae8d9871f5730",
+        "rev": "f9664ae058d67b8d97cb8a9c40744fefc3e5479f",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1756540347,
-        "narHash": "sha256-O306WrpZF8o7bNwx3fYZu5Qu6vHsS9k6rx01+e6ALwQ=",
+        "lastModified": 1761001623,
+        "narHash": "sha256-HpDrrMY2CMzHy8xX3Flxo4P1Mj92teEa0FjGEN2xI3s=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "c04f95b47c8e6a3c961f88f068dbb3d3caad3ad1",
+        "rev": "53a9c4bb40fcc8c834136a393fbbee0083f9c7a7",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1760948891,
+        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1758296614,
-        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
+        "lastModified": 1761266473,
+        "narHash": "sha256-QxCyKWBmuzI+eMhYV1JmbZsiUnBNATRP1EW34OBt5Vg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
+        "rev": "5c71d4a730bd3c972befff343bb074421e345937",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1752730890,
-        "narHash": "sha256-GES8fapSLGz36MMPRVNkSUWXUTtqvGQNXHjRmRLfJUY=",
+        "lastModified": 1761120675,
+        "narHash": "sha256-TEbh9zISiQcU82VwVoEbmXHnSGlUxTwvjJA9g9ErSDA=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "6ebb8cb87987b20264c09296166543fd3761d274",
+        "rev": "a037ed2a58fc0ebed9e93b9ef79b0646e648f719",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1758209717,
-        "narHash": "sha256-8aIgm7FnIIvrLTUuyKyGk7vVUASm+BYYMem3R0FugU8=",
+        "lastModified": 1760988177,
+        "narHash": "sha256-QaAjxpn7VHUdL8PFQcDUsa7xA/7bMtGaGl1aTpKOs2M=",
         "owner": "idursun",
         "repo": "jjui",
-        "rev": "03011dd5754166d3c1184b6b1ae4e635c3cdcf12",
+        "rev": "6e95d19846d33eb0fbd07d9563a2ad02cd9f9136",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1758102940,
-        "narHash": "sha256-wwqf3+A8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o=",
+        "lastModified": 1760721282,
+        "narHash": "sha256-aAHphQbU9t/b2RRy2Eb8oMv+I08isXv2KUGFAFn7nCo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd",
+        "rev": "c3211fcd0c56c11ff110d346d4487b18f7365168",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1757822619,
-        "narHash": "sha256-3HIpe3P2h1AUPYcAH9cjuX0tZOqJpX01c0iDwoUYNZ8=",
+        "lastModified": 1760846226,
+        "narHash": "sha256-xmU8kAsRprJiTGBTaGrwmjBP3AMA9ltlrxHKFuy5JWc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea",
+        "rev": "5024e1901239a76b7bf94a4cd27f3507e639d49e",
         "type": "github"
       },
       "original": {
@@ -326,11 +326,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758123407,
-        "narHash": "sha256-4qwMlR0Q4Zr2rjUFauYIldfjzffYt3G5tZ1uPFPPYGU=",
+        "lastModified": 1760536587,
+        "narHash": "sha256-wfWqt+igns/VazjPLkyb4Z/wpn4v+XIjUeI3xY/1ENg=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "ba2b3b6c0bc42442559a3b090f032bc8d501f5e3",
+        "rev": "f98ee1de1fa36eca63c67b600f5d617e184e82ea",
         "type": "github"
       },
       "original": {
@@ -387,11 +387,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1757746433,
-        "narHash": "sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn+odUBTaindgiziY=",
+        "lastModified": 1760596604,
+        "narHash": "sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6d7ec06d6868ac6d94c371458fc2391ded9ff13d",
+        "rev": "3cbe716e2346710d6e1f7c559363d14e11c32a43",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1754340878,
-        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "lastModified": 1760596604,
+        "narHash": "sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "rev": "3cbe716e2346710d6e1f7c559363d14e11c32a43",
         "type": "github"
       },
       "original": {
@@ -465,11 +465,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1760878510,
+        "narHash": "sha256-K5Osef2qexezUfs0alLvZ7nQFTGS9DL2oTVsIXsqLgs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "5e2a59a5b1a82f89f2c7e598302a9cacebb72a67",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1760524057,
+        "narHash": "sha256-EVAqOteLBFmd7pKkb0+FIUyzTF61VKi7YmvP1tw4nEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1759733170,
+        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1758262103,
-        "narHash": "sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8=",
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "12bd230118a1901a4a5d393f9f56b6ad7e571d01",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
         "type": "github"
       },
       "original": {
@@ -610,11 +610,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1758007585,
-        "narHash": "sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c=",
+        "lastModified": 1760998189,
+        "narHash": "sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f77d4cfa075c3de66fc9976b80e0c4fc69e2c139",
+        "rev": "5a7d18b5c55642df5c432aadb757140edfeb70b3",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1758206697,
-        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
+        "lastModified": 1760945191,
+        "narHash": "sha256-ZRVs8UqikBa4Ki3X4KCnMBtBW0ux1DaT35tgsnB1jM4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
+        "rev": "f56b1934f5f8fcab8deb5d38d42fd692632b47c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs Fri Oct 24 05:15:48 UTC 2025




```shell
$ nix flake update
unpacking 'github:vic/SPC/7217d72e2b2a6053fbb7e3ea3f5bdaac65d69327' into the Git cache...
unpacking 'github:spikespaz/allfollow/5e097ac8c6fb8b9e32a3c590090005abe853cccf' into the Git cache...
unpacking 'github:doomemacs/doomemacs/f9664ae058d67b8d97cb8a9c40744fefc3e5479f' into the Git cache...
unpacking 'github:mudler/edgevpn/45ace51385b5aad01ad8712853c90d559a339ee4' into the Git cache...
unpacking 'github:vic/flake-file/53a9c4bb40fcc8c834136a393fbbee0083f9c7a7' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/864599284fc7c0ba6357ed89ed5e2cd5040f0c04' into the Git cache...
unpacking 'github:nix-community/home-manager/5c71d4a730bd3c972befff343bb074421e345937' into the Git cache...
unpacking 'github:vic/import-tree/a037ed2a58fc0ebed9e93b9ef79b0646e648f719' into the Git cache...
unpacking 'github:idursun/jjui/6e95d19846d33eb0fbd07d9563a2ad02cd9f9136' into the Git cache...
unpacking 'github:LnL7/nix-darwin/c3211fcd0c56c11ff110d346d4487b18f7365168' into the Git cache...
unpacking 'github:nix-community/nix-index-database/5024e1901239a76b7bf94a4cd27f3507e639d49e' into the Git cache...
unpacking 'github:nix-community/nixos-wsl/f98ee1de1fa36eca63c67b600f5d617e184e82ea' into the Git cache...
unpacking 'github:nixos/nixpkgs/d5faa84122bc0a1fd5d378492efce4e289f8eac1' into the Git cache...
unpacking 'github:Mic92/sops-nix/5a7d18b5c55642df5c432aadb757140edfeb70b3' into the Git cache...
unpacking 'github:numtide/treefmt-nix/f56b1934f5f8fcab8deb5d38d42fd692632b47c2' into the Git cache...
unpacking 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d' into the Git cache...
warning: updating lock file '/home/runner/work/vix/vix/flake.lock':
• Updated input 'doom-emacs':
    'github:doomemacs/doomemacs/6ea4332b854d311d7ec8ae6384fae8d9871f5730?narHash=sha256-rbdKF2wGHEK29pXohXU69qccx4yI4i2iLS15b72KakQ%3D' (2025-09-19)
  → 'github:doomemacs/doomemacs/f9664ae058d67b8d97cb8a9c40744fefc3e5479f?narHash=sha256-voIvrHMgs2zFNtYDxVnyBpmSCE3NFZAhhcZsUneDMLw%3D' (2025-10-16)
• Updated input 'flake-file':
    'github:vic/flake-file/c04f95b47c8e6a3c961f88f068dbb3d3caad3ad1?narHash=sha256-O306WrpZF8o7bNwx3fYZu5Qu6vHsS9k6rx01%2Be6ALwQ%3D' (2025-08-30)
  → 'github:vic/flake-file/53a9c4bb40fcc8c834136a393fbbee0083f9c7a7?narHash=sha256-HpDrrMY2CMzHy8xX3Flxo4P1Mj92teEa0FjGEN2xI3s%3D' (2025-10-20)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751?narHash=sha256-%2BuWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw%3D' (2025-09-01)
  → 'github:hercules-ci/flake-parts/864599284fc7c0ba6357ed89ed5e2cd5040f0c04?narHash=sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4%3D' (2025-10-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/55b1f5b7b191572257545413b98e37abab2fdb00?narHash=sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY%2Bq0kQ%3D' (2025-09-19)
  → 'github:nix-community/home-manager/5c71d4a730bd3c972befff343bb074421e345937?narHash=sha256-QxCyKWBmuzI%2BeMhYV1JmbZsiUnBNATRP1EW34OBt5Vg%3D' (2025-10-24)
• Updated input 'home-manager/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1?narHash=sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/5e2a59a5b1a82f89f2c7e598302a9cacebb72a67?narHash=sha256-K5Osef2qexezUfs0alLvZ7nQFTGS9DL2oTVsIXsqLgs%3D' (2025-10-19)
• Updated input 'import-tree':
    'github:vic/import-tree/6ebb8cb87987b20264c09296166543fd3761d274?narHash=sha256-GES8fapSLGz36MMPRVNkSUWXUTtqvGQNXHjRmRLfJUY%3D' (2025-07-17)
  → 'github:vic/import-tree/a037ed2a58fc0ebed9e93b9ef79b0646e648f719?narHash=sha256-TEbh9zISiQcU82VwVoEbmXHnSGlUxTwvjJA9g9ErSDA%3D' (2025-10-22)
• Updated input 'jjui':
    'github:idursun/jjui/03011dd5754166d3c1184b6b1ae4e635c3cdcf12?narHash=sha256-8aIgm7FnIIvrLTUuyKyGk7vVUASm%2BBYYMem3R0FugU8%3D' (2025-09-18)
  → 'github:idursun/jjui/6e95d19846d33eb0fbd07d9563a2ad02cd9f9136?narHash=sha256-QaAjxpn7VHUdL8PFQcDUsa7xA/7bMtGaGl1aTpKOs2M%3D' (2025-10-20)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd?narHash=sha256-wwqf3%2BA8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o%3D' (2025-09-17)
  → 'github:LnL7/nix-darwin/c3211fcd0c56c11ff110d346d4487b18f7365168?narHash=sha256-aAHphQbU9t/b2RRy2Eb8oMv%2BI08isXv2KUGFAFn7nCo%3D' (2025-10-17)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea?narHash=sha256-3HIpe3P2h1AUPYcAH9cjuX0tZOqJpX01c0iDwoUYNZ8%3D' (2025-09-14)
  → 'github:nix-community/nix-index-database/5024e1901239a76b7bf94a4cd27f3507e639d49e?narHash=sha256-xmU8kAsRprJiTGBTaGrwmjBP3AMA9ltlrxHKFuy5JWc%3D' (2025-10-19)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1?narHash=sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/544961dfcce86422ba200ed9a0b00dd4b1486ec5?narHash=sha256-EVAqOteLBFmd7pKkb0%2BFIUyzTF61VKi7YmvP1tw4nEw%3D' (2025-10-15)
• Updated input 'nixos-wsl':
    'github:nix-community/nixos-wsl/ba2b3b6c0bc42442559a3b090f032bc8d501f5e3?narHash=sha256-4qwMlR0Q4Zr2rjUFauYIldfjzffYt3G5tZ1uPFPPYGU%3D' (2025-09-17)
  → 'github:nix-community/nixos-wsl/f98ee1de1fa36eca63c67b600f5d617e184e82ea?narHash=sha256-wfWqt%2Bigns/VazjPLkyb4Z/wpn4v%2BXIjUeI3xY/1ENg%3D' (2025-10-15)
• Updated input 'nixos-wsl/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1?narHash=sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/8913c168d1c56dc49a7718685968f38752171c3b?narHash=sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI%3D' (2025-10-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/12bd230118a1901a4a5d393f9f56b6ad7e571d01?narHash=sha256-aBGl3XEOsjWw6W3AHiKibN7FeoG73dutQQEqnd/etR8%3D' (2025-09-19)
  → 'github:nixos/nixpkgs/d5faa84122bc0a1fd5d378492efce4e289f8eac1?narHash=sha256-%2Bpthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE%2BfV2Q%3D' (2025-10-23)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f77d4cfa075c3de66fc9976b80e0c4fc69e2c139?narHash=sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c%3D' (2025-09-16)
  → 'github:Mic92/sops-nix/5a7d18b5c55642df5c432aadb757140edfeb70b3?narHash=sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY%3D' (2025-10-20)
• Updated input 'sops-nix/nixpkgs':
    'github:NixOS/nixpkgs/6d7ec06d6868ac6d94c371458fc2391ded9ff13d?narHash=sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn%2BodUBTaindgiziY%3D' (2025-09-13)
  → 'github:NixOS/nixpkgs/3cbe716e2346710d6e1f7c559363d14e11c32a43?narHash=sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM%3D' (2025-10-16)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/128222dc911b8e2e18939537bed1762b7f3a04aa?narHash=sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0%3D' (2025-09-18)
  → 'github:numtide/treefmt-nix/f56b1934f5f8fcab8deb5d38d42fd692632b47c2?narHash=sha256-ZRVs8UqikBa4Ki3X4KCnMBtBW0ux1DaT35tgsnB1jM4%3D' (2025-10-20)
• Updated input 'treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/cab778239e705082fe97bb4990e0d24c50924c04?narHash=sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU%3D' (2025-08-04)
  → 'github:nixos/nixpkgs/3cbe716e2346710d6e1f7c559363d14e11c32a43?narHash=sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM%3D' (2025-10-16)
warning: Git tree '/home/runner/work/vix/vix' is dirty
```




request-checks: true
