### PR TITLE
Updating inputs Wed Mar 25 05:59:39 UTC 2026

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "5728cf32f2f2a3c4b0e34ecfb211ce8c0131a3a7",
-      "url": "https://github.com/vic/den/archive/5728cf32f2f2a3c4b0e34ecfb211ce8c0131a3a7.tar.gz",
-      "hash": "sha256-aPfuEzOcd1Jaj+XkELOgDSX8DpM8YQCX1z8KKpKGJtY="
+      "revision": "508a5fa0b99da48fb837be5b5087e531b9cbb996",
+      "url": "https://github.com/vic/den/archive/508a5fa0b99da48fb837be5b5087e531b9cbb996.tar.gz",
+      "hash": "sha256-hL6AYBk4F4yFvW57Ds9oqAJS0oAgVYDcEJYhqPG1tXc="
     },
     "doom-emacs": {
       "type": "Git",
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "d8d75443d39d95f3c5256504eb838e0acc62ef44",
-      "url": "https://github.com/doomemacs/doomemacs/archive/d8d75443d39d95f3c5256504eb838e0acc62ef44.tar.gz",
-      "hash": "sha256-FYbalilgDFjIVwK+D6DjDos1IMmMGA20lRf8k6Ykm1Y="
+      "revision": "ba511fcbfb53d8922ede1600cf49076284a28e99",
+      "url": "https://github.com/doomemacs/doomemacs/archive/ba511fcbfb53d8922ede1600cf49076284a28e99.tar.gz",
+      "hash": "sha256-XwRbmOH03mYlF0UA7HmKvuRPOSuWOL2E40Y8WZd4o/w="
     },
     "edgevpn": {
       "type": "Git",
@@ -155,9 +155,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c6fe2944ad9f2444b2d767c4a5edee7c166e8a95",
-      "url": "https://github.com/nix-community/home-manager/archive/c6fe2944ad9f2444b2d767c4a5edee7c166e8a95.tar.gz",
-      "hash": "sha256-yeiWCY9aAUUJ3ebMVjs0UZXRnT5x90MCtpbpOWiXrvM="
+      "revision": "1eb0549a1ab3fe3f5acf86668249be15fa0e64f7",
+      "url": "https://github.com/nix-community/home-manager/archive/1eb0549a1ab3fe3f5acf86668249be15fa0e64f7.tar.gz",
+      "hash": "sha256-0nGNxWDUH2Hzlj/R3Zf4FEK6fsFNB/dvewuboSRZqiI="
     },
     "import-tree": {
       "type": "Git",
@@ -181,9 +181,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "24737015838c36df67765fc1527ee1b4587b548e",
-      "url": "https://github.com/idursun/jjui/archive/24737015838c36df67765fc1527ee1b4587b548e.tar.gz",
-      "hash": "sha256-E/i8xK51PMP0JwcBzaRy8Nzi4wG5PKqCsxmCB3bpnV4="
+      "revision": "c3c159664070a17970a5de55012288017bbffa79",
+      "url": "https://github.com/idursun/jjui/archive/c3c159664070a17970a5de55012288017bbffa79.tar.gz",
+      "hash": "sha256-gPyjlGW02b/WLM7xJUKHfHk0LIJvdENPgs3PxhuZ+Tc="
     },
     "mnw": {
       "type": "Git",
@@ -246,9 +246,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
-      "url": "https://github.com/nixos/nixpkgs/archive/9cf7092bdd603554bd8b63c216e8943cf9b12512.tar.gz",
-      "hash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0="
+      "revision": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+      "url": "https://github.com/nixos/nixpkgs/archive/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed.tar.gz",
+      "hash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA="
     },
     "nvf": {
       "type": "Git",
@@ -259,9 +259,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "edfb73fa4ced576f587d259a70a513b4152f8cea",
-      "url": "https://github.com/notashelf/nvf/archive/edfb73fa4ced576f587d259a70a513b4152f8cea.tar.gz",
-      "hash": "sha256-g45WZAZHNc7wJBkK4IdB5dq0Bh0JE7G0gcY2H5DFi44="
+      "revision": "d847d401bea4dcb1478d02a61a3209fa8512f71d",
+      "url": "https://github.com/notashelf/nvf/archive/d847d401bea4dcb1478d02a61a3209fa8512f71d.tar.gz",
+      "hash": "sha256-d22VIgsDXagQQWnAnebYeQWGHlmF81YRwuGCzAgNZAQ="
     },
     "sops-nix": {
       "type": "Git",
@@ -272,9 +272,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "3e0d543e6ba6c0c48117a81614e90c6d8c425170",
-      "url": "https://github.com/Mic92/sops-nix/archive/3e0d543e6ba6c0c48117a81614e90c6d8c425170.tar.gz",
-      "hash": "sha256-zsTuloDSdKf+PrI1MsWx5z/cyGEJ8P3eERtAfdP8Bmg="
+      "revision": "614e256310e0a4f8a9ccae3fa80c11844fba7042",
+      "url": "https://github.com/Mic92/sops-nix/archive/614e256310e0a4f8a9ccae3fa80c11844fba7042.tar.gz",
+      "hash": "sha256-fhG4JAcLgjKwt+XHbjs8brpWnyKUfU4LikLm3s0Q/ic="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Updating inputs Wed Mar 25 05:59:39 UTC 2026




```shell
$ npins update
[blueprint] No Changes
[SPC] No Changes
[darwin] No Changes
[enthium] No Changes
[edgevpn] No Changes
[flake-aspects] No Changes
[flake-file] No Changes
[flake-parts] No Changes
[helium] No Changes
[den] Changes:
-    revision: 5728cf32f2f2a3c4b0e34ecfb211ce8c0131a3a7
+    revision: 508a5fa0b99da48fb837be5b5087e531b9cbb996
-    url: https://github.com/vic/den/archive/5728cf32f2f2a3c4b0e34ecfb211ce8c0131a3a7.tar.gz
+    url: https://github.com/vic/den/archive/508a5fa0b99da48fb837be5b5087e531b9cbb996.tar.gz
-    hash: sha256-aPfuEzOcd1Jaj+XkELOgDSX8DpM8YQCX1z8KKpKGJtY=
+    hash: sha256-hL6AYBk4F4yFvW57Ds9oqAJS0oAgVYDcEJYhqPG1tXc=
[import-tree] No Changes
[doom-emacs] Changes:
-    revision: d8d75443d39d95f3c5256504eb838e0acc62ef44
+    revision: ba511fcbfb53d8922ede1600cf49076284a28e99
-    url: https://github.com/doomemacs/doomemacs/archive/d8d75443d39d95f3c5256504eb838e0acc62ef44.tar.gz
+    url: https://github.com/doomemacs/doomemacs/archive/ba511fcbfb53d8922ede1600cf49076284a28e99.tar.gz
-    hash: sha256-FYbalilgDFjIVwK+D6DjDos1IMmMGA20lRf8k6Ykm1Y=
+    hash: sha256-XwRbmOH03mYlF0UA7HmKvuRPOSuWOL2E40Y8WZd4o/w=
[mnw] No Changes
[nix-unit] No Changes
[nix-index-database] No Changes
[nixos-wsl] No Changes
[jjui] Changes:
-    revision: 24737015838c36df67765fc1527ee1b4587b548e
+    revision: c3c159664070a17970a5de55012288017bbffa79
-    url: https://github.com/idursun/jjui/archive/24737015838c36df67765fc1527ee1b4587b548e.tar.gz
+    url: https://github.com/idursun/jjui/archive/c3c159664070a17970a5de55012288017bbffa79.tar.gz
-    hash: sha256-E/i8xK51PMP0JwcBzaRy8Nzi4wG5PKqCsxmCB3bpnV4=
+    hash: sha256-gPyjlGW02b/WLM7xJUKHfHk0LIJvdENPgs3PxhuZ+Tc=
[treefmt-nix] No Changes
[sops-nix] Changes:
-    revision: 3e0d543e6ba6c0c48117a81614e90c6d8c425170
+    revision: 614e256310e0a4f8a9ccae3fa80c11844fba7042
-    url: https://github.com/Mic92/sops-nix/archive/3e0d543e6ba6c0c48117a81614e90c6d8c425170.tar.gz
+    url: https://github.com/Mic92/sops-nix/archive/614e256310e0a4f8a9ccae3fa80c11844fba7042.tar.gz
-    hash: sha256-zsTuloDSdKf+PrI1MsWx5z/cyGEJ8P3eERtAfdP8Bmg=
+    hash: sha256-fhG4JAcLgjKwt+XHbjs8brpWnyKUfU4LikLm3s0Q/ic=
[trix] No Changes
[vscode-server] No Changes
[nvf] Changes:
-    revision: edfb73fa4ced576f587d259a70a513b4152f8cea
+    revision: d847d401bea4dcb1478d02a61a3209fa8512f71d
-    url: https://github.com/notashelf/nvf/archive/edfb73fa4ced576f587d259a70a513b4152f8cea.tar.gz
+    url: https://github.com/notashelf/nvf/archive/d847d401bea4dcb1478d02a61a3209fa8512f71d.tar.gz
-    hash: sha256-g45WZAZHNc7wJBkK4IdB5dq0Bh0JE7G0gcY2H5DFi44=
+    hash: sha256-d22VIgsDXagQQWnAnebYeQWGHlmF81YRwuGCzAgNZAQ=
[with-inputs] No Changes
[home-manager] Changes:
-    revision: c6fe2944ad9f2444b2d767c4a5edee7c166e8a95
+    revision: 1eb0549a1ab3fe3f5acf86668249be15fa0e64f7
-    url: https://github.com/nix-community/home-manager/archive/c6fe2944ad9f2444b2d767c4a5edee7c166e8a95.tar.gz
+    url: https://github.com/nix-community/home-manager/archive/1eb0549a1ab3fe3f5acf86668249be15fa0e64f7.tar.gz
-    hash: sha256-yeiWCY9aAUUJ3ebMVjs0UZXRnT5x90MCtpbpOWiXrvM=
+    hash: sha256-0nGNxWDUH2Hzlj/R3Zf4FEK6fsFNB/dvewuboSRZqiI=
[nixpkgs] Changes:
-    revision: 9cf7092bdd603554bd8b63c216e8943cf9b12512
+    revision: fdc7b8f7b30fdbedec91b71ed82f36e1637483ed
-    url: https://github.com/nixos/nixpkgs/archive/9cf7092bdd603554bd8b63c216e8943cf9b12512.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed.tar.gz
-    hash: sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=
+    hash: sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=
[INFO ] Update successful.
```




request-checks: true
