### PR TITLE
Updating inputs Wed Mar 25 17:41:41 UTC 2026

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "508a5fa0b99da48fb837be5b5087e531b9cbb996",
-      "url": "https://github.com/vic/den/archive/508a5fa0b99da48fb837be5b5087e531b9cbb996.tar.gz",
-      "hash": "sha256-hL6AYBk4F4yFvW57Ds9oqAJS0oAgVYDcEJYhqPG1tXc="
+      "revision": "4db9eea2e6f08d91ead6959053d1eb6613438ec9",
+      "url": "https://github.com/vic/den/archive/4db9eea2e6f08d91ead6959053d1eb6613438ec9.tar.gz",
+      "hash": "sha256-G6HmJU6SUbSgDTru85xAFeOU8+q8CFoPCIOn3qQJYbA="
     },
     "doom-emacs": {
       "type": "Git",
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "ba511fcbfb53d8922ede1600cf49076284a28e99",
-      "url": "https://github.com/doomemacs/doomemacs/archive/ba511fcbfb53d8922ede1600cf49076284a28e99.tar.gz",
-      "hash": "sha256-XwRbmOH03mYlF0UA7HmKvuRPOSuWOL2E40Y8WZd4o/w="
+      "revision": "43912efdcbc9d63f84becfd6cfde86dec04c168d",
+      "url": "https://github.com/doomemacs/doomemacs/archive/43912efdcbc9d63f84becfd6cfde86dec04c168d.tar.gz",
+      "hash": "sha256-j0WGkNnL3QhEUA1y770myqePFM4EnIHOLsi5+5+1BXg="
     },
     "edgevpn": {
       "type": "Git",


### PR DESCRIPTION
Updating inputs Wed Mar 25 17:41:41 UTC 2026




```shell
$ npins update
[SPC] No Changes
[blueprint] No Changes
[darwin] No Changes
[enthium] No Changes
[edgevpn] No Changes
[flake-aspects] No Changes
[flake-file] No Changes
[helium] No Changes
[flake-parts] No Changes
[den] Changes:
-    revision: 508a5fa0b99da48fb837be5b5087e531b9cbb996
+    revision: 4db9eea2e6f08d91ead6959053d1eb6613438ec9
-    url: https://github.com/vic/den/archive/508a5fa0b99da48fb837be5b5087e531b9cbb996.tar.gz
+    url: https://github.com/vic/den/archive/4db9eea2e6f08d91ead6959053d1eb6613438ec9.tar.gz
-    hash: sha256-hL6AYBk4F4yFvW57Ds9oqAJS0oAgVYDcEJYhqPG1tXc=
+    hash: sha256-G6HmJU6SUbSgDTru85xAFeOU8+q8CFoPCIOn3qQJYbA=
[import-tree] No Changes
[mnw] No Changes
[jjui] No Changes
[home-manager] No Changes
[nix-index-database] No Changes
[doom-emacs] Changes:
-    revision: ba511fcbfb53d8922ede1600cf49076284a28e99
+    revision: 43912efdcbc9d63f84becfd6cfde86dec04c168d
-    url: https://github.com/doomemacs/doomemacs/archive/ba511fcbfb53d8922ede1600cf49076284a28e99.tar.gz
+    url: https://github.com/doomemacs/doomemacs/archive/43912efdcbc9d63f84becfd6cfde86dec04c168d.tar.gz
-    hash: sha256-XwRbmOH03mYlF0UA7HmKvuRPOSuWOL2E40Y8WZd4o/w=
+    hash: sha256-j0WGkNnL3QhEUA1y770myqePFM4EnIHOLsi5+5+1BXg=
[nix-unit] No Changes
[nixos-wsl] No Changes
[nvf] No Changes
[treefmt-nix] No Changes
[trix] No Changes
[vscode-server] No Changes
[with-inputs] No Changes
[sops-nix] No Changes
[nixpkgs] No Changes
[INFO ] Update successful.
```




request-checks: true
