### PR TITLE
Updating inputs Fri Mar 27 06:12:29 UTC 2026

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "508a5fa0b99da48fb837be5b5087e531b9cbb996",
-      "url": "https://github.com/vic/den/archive/508a5fa0b99da48fb837be5b5087e531b9cbb996.tar.gz",
-      "hash": "sha256-hL6AYBk4F4yFvW57Ds9oqAJS0oAgVYDcEJYhqPG1tXc="
+      "revision": "f3c1fd0dcd17a2ea2885db0f5a05e15c2d0a084c",
+      "url": "https://github.com/vic/den/archive/f3c1fd0dcd17a2ea2885db0f5a05e15c2d0a084c.tar.gz",
+      "hash": "sha256-Z7GFJq8gUIb/PdgYpCxfVTg6giygOczL0yqiQmmLBfM="
     },
     "doom-emacs": {
       "type": "Git",
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "ba511fcbfb53d8922ede1600cf49076284a28e99",
-      "url": "https://github.com/doomemacs/doomemacs/archive/ba511fcbfb53d8922ede1600cf49076284a28e99.tar.gz",
-      "hash": "sha256-XwRbmOH03mYlF0UA7HmKvuRPOSuWOL2E40Y8WZd4o/w="
+      "revision": "78129e4727ddca3a17fbc3215a6082f06bf5ccd0",
+      "url": "https://github.com/doomemacs/doomemacs/archive/78129e4727ddca3a17fbc3215a6082f06bf5ccd0.tar.gz",
+      "hash": "sha256-p+Xcya6P6wnggo24Wclq5FMUBTJ1E5X9hNx/Fm1tpMU="
     },
     "edgevpn": {
       "type": "Git",
@@ -142,9 +142,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "67aa32deed6927e75a6e3fe70004bb3ad82d650c",
-      "url": "https://github.com/vikingnope/helium-browser-nix-flake/archive/67aa32deed6927e75a6e3fe70004bb3ad82d650c.tar.gz",
-      "hash": "sha256-6tDR417MA6RPFN90kTI+YZOanjeb01di8bVp3ME6JJw="
+      "revision": "5339187341b31049c3116c8a52b2fc80362c83f3",
+      "url": "https://github.com/vikingnope/helium-browser-nix-flake/archive/5339187341b31049c3116c8a52b2fc80362c83f3.tar.gz",
+      "hash": "sha256-KYfvrXdr4U+J9evCJ1AkWhv1/QFy5Telmc1KHor3xgA="
     },
     "home-manager": {
       "type": "Git",
@@ -155,9 +155,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "1eb0549a1ab3fe3f5acf86668249be15fa0e64f7",
-      "url": "https://github.com/nix-community/home-manager/archive/1eb0549a1ab3fe3f5acf86668249be15fa0e64f7.tar.gz",
-      "hash": "sha256-0nGNxWDUH2Hzlj/R3Zf4FEK6fsFNB/dvewuboSRZqiI="
+      "revision": "4b1be5c38be350ee9452a4847945ce71d950dc31",
+      "url": "https://github.com/nix-community/home-manager/archive/4b1be5c38be350ee9452a4847945ce71d950dc31.tar.gz",
+      "hash": "sha256-uWR9fC+4NykFJVn4GN4Ini9LX+w8Llj7BnWKKp0N6bw="
     },
     "import-tree": {
       "type": "Git",
@@ -246,9 +246,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
-      "url": "https://github.com/nixos/nixpkgs/archive/9cf7092bdd603554bd8b63c216e8943cf9b12512.tar.gz",
-      "hash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0="
+      "revision": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+      "url": "https://github.com/nixos/nixpkgs/archive/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed.tar.gz",
+      "hash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA="
     },
     "nvf": {
       "type": "Git",


### PR DESCRIPTION
Updating inputs Fri Mar 27 06:12:29 UTC 2026




```shell
$ npins update
[blueprint] No Changes
[SPC] No Changes
[darwin] No Changes
[enthium] No Changes
[edgevpn] No Changes
[flake-aspects] No Changes
[flake-file] No Changes
[flake-parts] No Changes
[den] Changes:
-    revision: 508a5fa0b99da48fb837be5b5087e531b9cbb996
+    revision: f3c1fd0dcd17a2ea2885db0f5a05e15c2d0a084c
-    url: https://github.com/vic/den/archive/508a5fa0b99da48fb837be5b5087e531b9cbb996.tar.gz
+    url: https://github.com/vic/den/archive/f3c1fd0dcd17a2ea2885db0f5a05e15c2d0a084c.tar.gz
-    hash: sha256-hL6AYBk4F4yFvW57Ds9oqAJS0oAgVYDcEJYhqPG1tXc=
+    hash: sha256-Z7GFJq8gUIb/PdgYpCxfVTg6giygOczL0yqiQmmLBfM=
[import-tree] No Changes
[jjui] No Changes
[mnw] No Changes
[helium] Changes:
-    revision: 67aa32deed6927e75a6e3fe70004bb3ad82d650c
+    revision: 5339187341b31049c3116c8a52b2fc80362c83f3
-    url: https://github.com/vikingnope/helium-browser-nix-flake/archive/67aa32deed6927e75a6e3fe70004bb3ad82d650c.tar.gz
+    url: https://github.com/vikingnope/helium-browser-nix-flake/archive/5339187341b31049c3116c8a52b2fc80362c83f3.tar.gz
-    hash: sha256-6tDR417MA6RPFN90kTI+YZOanjeb01di8bVp3ME6JJw=
+    hash: sha256-KYfvrXdr4U+J9evCJ1AkWhv1/QFy5Telmc1KHor3xgA=
[doom-emacs] Changes:
-    revision: ba511fcbfb53d8922ede1600cf49076284a28e99
+    revision: 78129e4727ddca3a17fbc3215a6082f06bf5ccd0
-    url: https://github.com/doomemacs/doomemacs/archive/ba511fcbfb53d8922ede1600cf49076284a28e99.tar.gz
+    url: https://github.com/doomemacs/doomemacs/archive/78129e4727ddca3a17fbc3215a6082f06bf5ccd0.tar.gz
-    hash: sha256-XwRbmOH03mYlF0UA7HmKvuRPOSuWOL2E40Y8WZd4o/w=
+    hash: sha256-p+Xcya6P6wnggo24Wclq5FMUBTJ1E5X9hNx/Fm1tpMU=
[nix-index-database] No Changes
[nix-unit] No Changes
[nixos-wsl] No Changes
[nvf] No Changes
[sops-nix] No Changes
[treefmt-nix] No Changes
[vscode-server] No Changes
[trix] No Changes
[with-inputs] No Changes
[home-manager] Changes:
-    revision: 1eb0549a1ab3fe3f5acf86668249be15fa0e64f7
+    revision: 4b1be5c38be350ee9452a4847945ce71d950dc31
-    url: https://github.com/nix-community/home-manager/archive/1eb0549a1ab3fe3f5acf86668249be15fa0e64f7.tar.gz
+    url: https://github.com/nix-community/home-manager/archive/4b1be5c38be350ee9452a4847945ce71d950dc31.tar.gz
-    hash: sha256-0nGNxWDUH2Hzlj/R3Zf4FEK6fsFNB/dvewuboSRZqiI=
+    hash: sha256-uWR9fC+4NykFJVn4GN4Ini9LX+w8Llj7BnWKKp0N6bw=
[nixpkgs] Changes:
-    revision: 9cf7092bdd603554bd8b63c216e8943cf9b12512
+    revision: fdc7b8f7b30fdbedec91b71ed82f36e1637483ed
-    url: https://github.com/nixos/nixpkgs/archive/9cf7092bdd603554bd8b63c216e8943cf9b12512.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed.tar.gz
-    hash: sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=
+    hash: sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=
[INFO ] Update successful.
```




request-checks: true
