### PR TITLE
Updating inputs Tue Apr 21 06:57:58 UTC 2026

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "feat/fx-resolution",
       "submodules": false,
-      "revision": "c160af184853b87cbfa1ec384cb72b53170f2f9f",
-      "url": "https://github.com/sini/den/archive/c160af184853b87cbfa1ec384cb72b53170f2f9f.tar.gz",
-      "hash": "sha256-tFldZ+PKpU/2tuU4KuYC/Uq4JE5kc4yGCLuawTAshZw="
+      "revision": "72ac20af13abea80065db4c9247f9837a6e60e1d",
+      "url": "https://github.com/sini/den/archive/72ac20af13abea80065db4c9247f9837a6e60e1d.tar.gz",
+      "hash": "sha256-pgN5sWAJCWMqurI6pG7zgfFSYGy5xElQzpoGZCREies="
     },
     "doom-emacs": {
       "type": "Git",
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "5eb006f455f0558c97210ba7579880aacb045b67",
-      "url": "https://github.com/doomemacs/doomemacs/archive/5eb006f455f0558c97210ba7579880aacb045b67.tar.gz",
-      "hash": "sha256-6nuelk+8qSRsh5Ryj9EpWOWXeeh/g3lI5mZsBfiFZQI="
+      "revision": "707da6f7e90f26a4e00e5f8f98f29fd08824e71e",
+      "url": "https://github.com/doomemacs/doomemacs/archive/707da6f7e90f26a4e00e5f8f98f29fd08824e71e.tar.gz",
+      "hash": "sha256-wU0gAHaCCX/sTUvbsgSxXAPxb1xEazfu5PClDe3SbXA="
     },
     "edgevpn": {
       "type": "Git",
@@ -142,9 +142,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "6ae2aaea1a019b8f52886041e6779919d1c1cc60",
-      "url": "https://github.com/vikingnope/helium-browser-nix-flake/archive/6ae2aaea1a019b8f52886041e6779919d1c1cc60.tar.gz",
-      "hash": "sha256-0F+Snir+cD8HRGlf0vpvkhyjUT9HI6Qr+Z3JmUlEtSU="
+      "revision": "33dfb6d7e53e5b568690ede1e0299d2fdae56868",
+      "url": "https://github.com/vikingnope/helium-browser-nix-flake/archive/33dfb6d7e53e5b568690ede1e0299d2fdae56868.tar.gz",
+      "hash": "sha256-+EvL6D/ENSouidMse/QdokaHUZTgyCYmW8k6xaCqImk="
     },
     "home-manager": {
       "type": "Git",
@@ -155,9 +155,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "d401492e2acd4fea42f7705a3c266cea739c9c36",
-      "url": "https://github.com/nix-community/home-manager/archive/d401492e2acd4fea42f7705a3c266cea739c9c36.tar.gz",
-      "hash": "sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs="
+      "revision": "c555a4a34a260493be5adb795c54e013c58f2d34",
+      "url": "https://github.com/nix-community/home-manager/archive/c555a4a34a260493be5adb795c54e013c58f2d34.tar.gz",
+      "hash": "sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U="
     },
     "import-tree": {
       "type": "Git",
@@ -181,9 +181,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa",
-      "url": "https://github.com/idursun/jjui/archive/f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa.tar.gz",
-      "hash": "sha256-bvYeFLkt4ly0WrKUvE1QQdM3/RULSuI61DSKrTfG6+Q="
+      "revision": "bd7a9e06234bc1821fa833aca3ae9264b39e0f86",
+      "url": "https://github.com/idursun/jjui/archive/bd7a9e06234bc1821fa833aca3ae9264b39e0f86.tar.gz",
+      "hash": "sha256-yxPvWthVn4a6SRPXwdBOpHTKLXxb66Vs05/cI2e+SUc="
     },
     "mnw": {
       "type": "Git",
@@ -194,9 +194,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3",
-      "url": "https://github.com/Gerg-L/mnw/archive/6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3.tar.gz",
-      "hash": "sha256-mR8GDvGPu1QcI5Ft5lV2CIIh5Og7zRylts+XY3fa/K4="
+      "revision": "54f7ad6e34f4e44e0260a5140af7726a4792dece",
+      "url": "https://github.com/Gerg-L/mnw/archive/54f7ad6e34f4e44e0260a5140af7726a4792dece.tar.gz",
+      "hash": "sha256-AHM3wNuC5zzGaygnovHqFUI0YJR1Jj7ZgK9D9m7cgMQ="
     },
     "nix-index-database": {
       "type": "Git",
@@ -207,9 +207,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "bedba5989b04614fc598af9633033b95a937933f",
-      "url": "https://github.com/nix-community/nix-index-database/archive/bedba5989b04614fc598af9633033b95a937933f.tar.gz",
-      "hash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk="
+      "revision": "3b9653a107c736222b5ae0d4036dd3b885219065",
+      "url": "https://github.com/nix-community/nix-index-database/archive/3b9653a107c736222b5ae0d4036dd3b885219065.tar.gz",
+      "hash": "sha256-28Gqz0GDpGsBv8GtAn2dywEQRr+CtTDsD5J7VD6icBE="
     },
     "nix-unit": {
       "type": "Git",
@@ -233,9 +233,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911",
-      "url": "https://github.com/nix-community/nixos-wsl/archive/9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911.tar.gz",
-      "hash": "sha256-LQjlc0VEn55WAT4BiI8sIsokb/2FNlcbBD+Xr3MTE24="
+      "revision": "51b302c28dbf904a5c341be005eebe0779cf4f16",
+      "url": "https://github.com/nix-community/nixos-wsl/archive/51b302c28dbf904a5c341be005eebe0779cf4f16.tar.gz",
+      "hash": "sha256-7Q05rUgwbkJnjxIJyi8bHUG+XnyZqLxFJz7c8RncpeU="
     },
     "nixpkgs": {
       "type": "Git",
@@ -246,9 +246,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "566acc07c54dc807f91625bb286cb9b321b5f42a",
-      "url": "https://github.com/nixos/nixpkgs/archive/566acc07c54dc807f91625bb286cb9b321b5f42a.tar.gz",
-      "hash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y="
+      "revision": "b86751bc4085f48661017fa226dee99fab6c651b",
+      "url": "https://github.com/nixos/nixpkgs/archive/b86751bc4085f48661017fa226dee99fab6c651b.tar.gz",
+      "hash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw="
     },
     "nvf": {
       "type": "Git",
@@ -259,9 +259,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "029ca6d34ad8d830afb56a9963e4baed53848da6",
-      "url": "https://github.com/notashelf/nvf/archive/029ca6d34ad8d830afb56a9963e4baed53848da6.tar.gz",
-      "hash": "sha256-N/I4lxWjes7E8n4NEOYaNxxvJ9db+RKHJSH8oDdqR8o="
+      "revision": "4de19e12094a30d3cd205822536e0c3c57cba66c",
+      "url": "https://github.com/notashelf/nvf/archive/4de19e12094a30d3cd205822536e0c3c57cba66c.tar.gz",
+      "hash": "sha256-XXn/vKRCiwCkAzXvOxNyLE0mRDfFa0axQDJYMikaGY8="
     },
     "sops-nix": {
       "type": "Git",


### PR DESCRIPTION
Updating inputs Tue Apr 21 06:57:58 UTC 2026




```shell
$ npins update
[SPC] No Changes
[darwin] No Changes
[blueprint] No Changes
[flake-aspects] No Changes
[enthium] No Changes
[flake-file] No Changes
[edgevpn] No Changes
[flake-parts] No Changes
[import-tree] No Changes
[doom-emacs] Changes:
-    revision: 5eb006f455f0558c97210ba7579880aacb045b67
+    revision: 707da6f7e90f26a4e00e5f8f98f29fd08824e71e
-    url: https://github.com/doomemacs/doomemacs/archive/5eb006f455f0558c97210ba7579880aacb045b67.tar.gz
+    url: https://github.com/doomemacs/doomemacs/archive/707da6f7e90f26a4e00e5f8f98f29fd08824e71e.tar.gz
-    hash: sha256-6nuelk+8qSRsh5Ryj9EpWOWXeeh/g3lI5mZsBfiFZQI=
+    hash: sha256-wU0gAHaCCX/sTUvbsgSxXAPxb1xEazfu5PClDe3SbXA=
[den] Changes:
-    revision: c160af184853b87cbfa1ec384cb72b53170f2f9f
+    revision: 72ac20af13abea80065db4c9247f9837a6e60e1d
-    url: https://github.com/sini/den/archive/c160af184853b87cbfa1ec384cb72b53170f2f9f.tar.gz
+    url: https://github.com/sini/den/archive/72ac20af13abea80065db4c9247f9837a6e60e1d.tar.gz
-    hash: sha256-tFldZ+PKpU/2tuU4KuYC/Uq4JE5kc4yGCLuawTAshZw=
+    hash: sha256-pgN5sWAJCWMqurI6pG7zgfFSYGy5xElQzpoGZCREies=
[helium] Changes:
-    revision: 6ae2aaea1a019b8f52886041e6779919d1c1cc60
+    revision: 33dfb6d7e53e5b568690ede1e0299d2fdae56868
-    url: https://github.com/vikingnope/helium-browser-nix-flake/archive/6ae2aaea1a019b8f52886041e6779919d1c1cc60.tar.gz
+    url: https://github.com/vikingnope/helium-browser-nix-flake/archive/33dfb6d7e53e5b568690ede1e0299d2fdae56868.tar.gz
-    hash: sha256-0F+Snir+cD8HRGlf0vpvkhyjUT9HI6Qr+Z3JmUlEtSU=
+    hash: sha256-+EvL6D/ENSouidMse/QdokaHUZTgyCYmW8k6xaCqImk=
[nix-unit] No Changes
[jjui] Changes:
-    revision: f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa
+    revision: bd7a9e06234bc1821fa833aca3ae9264b39e0f86
-    url: https://github.com/idursun/jjui/archive/f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa.tar.gz
+    url: https://github.com/idursun/jjui/archive/bd7a9e06234bc1821fa833aca3ae9264b39e0f86.tar.gz
-    hash: sha256-bvYeFLkt4ly0WrKUvE1QQdM3/RULSuI61DSKrTfG6+Q=
+    hash: sha256-yxPvWthVn4a6SRPXwdBOpHTKLXxb66Vs05/cI2e+SUc=
[nix-index-database] Changes:
-    revision: bedba5989b04614fc598af9633033b95a937933f
+    revision: 3b9653a107c736222b5ae0d4036dd3b885219065
-    url: https://github.com/nix-community/nix-index-database/archive/bedba5989b04614fc598af9633033b95a937933f.tar.gz
+    url: https://github.com/nix-community/nix-index-database/archive/3b9653a107c736222b5ae0d4036dd3b885219065.tar.gz
-    hash: sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=
+    hash: sha256-28Gqz0GDpGsBv8GtAn2dywEQRr+CtTDsD5J7VD6icBE=
[mnw] Changes:
-    revision: 6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3
+    revision: 54f7ad6e34f4e44e0260a5140af7726a4792dece
-    url: https://github.com/Gerg-L/mnw/archive/6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3.tar.gz
+    url: https://github.com/Gerg-L/mnw/archive/54f7ad6e34f4e44e0260a5140af7726a4792dece.tar.gz
-    hash: sha256-mR8GDvGPu1QcI5Ft5lV2CIIh5Og7zRylts+XY3fa/K4=
+    hash: sha256-AHM3wNuC5zzGaygnovHqFUI0YJR1Jj7ZgK9D9m7cgMQ=
[nixos-wsl] Changes:
-    revision: 9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911
+    revision: 51b302c28dbf904a5c341be005eebe0779cf4f16
-    url: https://github.com/nix-community/nixos-wsl/archive/9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911.tar.gz
+    url: https://github.com/nix-community/nixos-wsl/archive/51b302c28dbf904a5c341be005eebe0779cf4f16.tar.gz
-    hash: sha256-LQjlc0VEn55WAT4BiI8sIsokb/2FNlcbBD+Xr3MTE24=
+    hash: sha256-7Q05rUgwbkJnjxIJyi8bHUG+XnyZqLxFJz7c8RncpeU=
[sops-nix] No Changes
[trix] No Changes
[treefmt-nix] No Changes
[vscode-server] No Changes
[with-inputs] No Changes
[nvf] Changes:
-    revision: 029ca6d34ad8d830afb56a9963e4baed53848da6
+    revision: 4de19e12094a30d3cd205822536e0c3c57cba66c
-    url: https://github.com/notashelf/nvf/archive/029ca6d34ad8d830afb56a9963e4baed53848da6.tar.gz
+    url: https://github.com/notashelf/nvf/archive/4de19e12094a30d3cd205822536e0c3c57cba66c.tar.gz
-    hash: sha256-N/I4lxWjes7E8n4NEOYaNxxvJ9db+RKHJSH8oDdqR8o=
+    hash: sha256-XXn/vKRCiwCkAzXvOxNyLE0mRDfFa0axQDJYMikaGY8=
[home-manager] Changes:
-    revision: d401492e2acd4fea42f7705a3c266cea739c9c36
+    revision: c555a4a34a260493be5adb795c54e013c58f2d34
-    url: https://github.com/nix-community/home-manager/archive/d401492e2acd4fea42f7705a3c266cea739c9c36.tar.gz
+    url: https://github.com/nix-community/home-manager/archive/c555a4a34a260493be5adb795c54e013c58f2d34.tar.gz
-    hash: sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs=
+    hash: sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U=
[nixpkgs] Changes:
-    revision: 566acc07c54dc807f91625bb286cb9b321b5f42a
+    revision: b86751bc4085f48661017fa226dee99fab6c651b
-    url: https://github.com/nixos/nixpkgs/archive/566acc07c54dc807f91625bb286cb9b321b5f42a.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/b86751bc4085f48661017fa226dee99fab6c651b.tar.gz
-    hash: sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=
+    hash: sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=
[INFO ] Update successful.
```




request-checks: true
