### PR TITLE
Updating inputs Sun Apr 26 06:58:35 UTC 2026

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "feat/fx-resolution",
       "submodules": false,
-      "revision": "c160af184853b87cbfa1ec384cb72b53170f2f9f",
-      "url": "https://github.com/sini/den/archive/c160af184853b87cbfa1ec384cb72b53170f2f9f.tar.gz",
-      "hash": "sha256-tFldZ+PKpU/2tuU4KuYC/Uq4JE5kc4yGCLuawTAshZw="
+      "revision": "72ac20af13abea80065db4c9247f9837a6e60e1d",
+      "url": "https://github.com/sini/den/archive/72ac20af13abea80065db4c9247f9837a6e60e1d.tar.gz",
+      "hash": "sha256-pgN5sWAJCWMqurI6pG7zgfFSYGy5xElQzpoGZCREies="
     },
     "doom-emacs": {
       "type": "Git",
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "5eb006f455f0558c97210ba7579880aacb045b67",
-      "url": "https://github.com/doomemacs/doomemacs/archive/5eb006f455f0558c97210ba7579880aacb045b67.tar.gz",
-      "hash": "sha256-6nuelk+8qSRsh5Ryj9EpWOWXeeh/g3lI5mZsBfiFZQI="
+      "revision": "3baa406d6596eb52e38461e6de4393f69d5cbd3a",
+      "url": "https://github.com/doomemacs/doomemacs/archive/3baa406d6596eb52e38461e6de4393f69d5cbd3a.tar.gz",
+      "hash": "sha256-JPG63N+9+YRpfgaY6L6n7a0aS5SYHKYmzj+Uuu1KVQ0="
     },
     "edgevpn": {
       "type": "Git",
@@ -142,9 +142,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "6ae2aaea1a019b8f52886041e6779919d1c1cc60",
-      "url": "https://github.com/vikingnope/helium-browser-nix-flake/archive/6ae2aaea1a019b8f52886041e6779919d1c1cc60.tar.gz",
-      "hash": "sha256-0F+Snir+cD8HRGlf0vpvkhyjUT9HI6Qr+Z3JmUlEtSU="
+      "revision": "33dfb6d7e53e5b568690ede1e0299d2fdae56868",
+      "url": "https://github.com/vikingnope/helium-browser-nix-flake/archive/33dfb6d7e53e5b568690ede1e0299d2fdae56868.tar.gz",
+      "hash": "sha256-+EvL6D/ENSouidMse/QdokaHUZTgyCYmW8k6xaCqImk="
     },
     "home-manager": {
       "type": "Git",
@@ -155,9 +155,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "d401492e2acd4fea42f7705a3c266cea739c9c36",
-      "url": "https://github.com/nix-community/home-manager/archive/d401492e2acd4fea42f7705a3c266cea739c9c36.tar.gz",
-      "hash": "sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs="
+      "revision": "6f59831b23d03bbf4fbd13ad167ae25da294cc14",
+      "url": "https://github.com/nix-community/home-manager/archive/6f59831b23d03bbf4fbd13ad167ae25da294cc14.tar.gz",
+      "hash": "sha256-Th3a5OZyEy4kCoyLfefnt+2dwRIrFQqYgMsayF9qzFw="
     },
     "import-tree": {
       "type": "Git",
@@ -181,9 +181,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa",
-      "url": "https://github.com/idursun/jjui/archive/f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa.tar.gz",
-      "hash": "sha256-bvYeFLkt4ly0WrKUvE1QQdM3/RULSuI61DSKrTfG6+Q="
+      "revision": "96911e3f14b377fdb2d7c89e510c7cd558ee9098",
+      "url": "https://github.com/idursun/jjui/archive/96911e3f14b377fdb2d7c89e510c7cd558ee9098.tar.gz",
+      "hash": "sha256-gfZ4St30QwAO96H74fPsXG1MGDadiEIJ3jxXer0Qucs="
     },
     "mnw": {
       "type": "Git",
@@ -194,9 +194,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3",
-      "url": "https://github.com/Gerg-L/mnw/archive/6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3.tar.gz",
-      "hash": "sha256-mR8GDvGPu1QcI5Ft5lV2CIIh5Og7zRylts+XY3fa/K4="
+      "revision": "54f7ad6e34f4e44e0260a5140af7726a4792dece",
+      "url": "https://github.com/Gerg-L/mnw/archive/54f7ad6e34f4e44e0260a5140af7726a4792dece.tar.gz",
+      "hash": "sha256-AHM3wNuC5zzGaygnovHqFUI0YJR1Jj7ZgK9D9m7cgMQ="
     },
     "nix-index-database": {
       "type": "Git",
@@ -207,9 +207,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "bedba5989b04614fc598af9633033b95a937933f",
-      "url": "https://github.com/nix-community/nix-index-database/archive/bedba5989b04614fc598af9633033b95a937933f.tar.gz",
-      "hash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk="
+      "revision": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
+      "url": "https://github.com/nix-community/nix-index-database/archive/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa.tar.gz",
+      "hash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8="
     },
     "nix-unit": {
       "type": "Git",
@@ -220,9 +220,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "1c9ab50554eed0b768f9e5b6f646d63c9673f0f7",
-      "url": "https://github.com/nix-community/nix-unit/archive/1c9ab50554eed0b768f9e5b6f646d63c9673f0f7.tar.gz",
-      "hash": "sha256-hRADkHjNt41+JUHw2EiSkMaL4owL83g5ZppjYUdF/Dc="
+      "revision": "02e6597889281382303cbb7973748f04f2940e1a",
+      "url": "https://github.com/nix-community/nix-unit/archive/02e6597889281382303cbb7973748f04f2940e1a.tar.gz",
+      "hash": "sha256-vZfRXBDC9FTO2Vpz8TroVMqOYqp+hcVk6Nwx6+kRN1Q="
     },
     "nixos-wsl": {
       "type": "Git",
@@ -233,9 +233,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911",
-      "url": "https://github.com/nix-community/nixos-wsl/archive/9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911.tar.gz",
-      "hash": "sha256-LQjlc0VEn55WAT4BiI8sIsokb/2FNlcbBD+Xr3MTE24="
+      "revision": "4e6cad241baa0115a7aae8c55b04c166da4997c9",
+      "url": "https://github.com/nix-community/nixos-wsl/archive/4e6cad241baa0115a7aae8c55b04c166da4997c9.tar.gz",
+      "hash": "sha256-0ku3gW8bZ9TTpEU2fQw86oU6ZLT2vF6pacF+cLaf7VY="
     },
     "nixpkgs": {
       "type": "Git",
@@ -246,9 +246,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "566acc07c54dc807f91625bb286cb9b321b5f42a",
-      "url": "https://github.com/nixos/nixpkgs/archive/566acc07c54dc807f91625bb286cb9b321b5f42a.tar.gz",
-      "hash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y="
+      "revision": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+      "url": "https://github.com/nixos/nixpkgs/archive/01fbdeef22b76df85ea168fbfe1bfd9e63681b30.tar.gz",
+      "hash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw="
     },
     "nvf": {
       "type": "Git",
@@ -259,9 +259,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "029ca6d34ad8d830afb56a9963e4baed53848da6",
-      "url": "https://github.com/notashelf/nvf/archive/029ca6d34ad8d830afb56a9963e4baed53848da6.tar.gz",
-      "hash": "sha256-N/I4lxWjes7E8n4NEOYaNxxvJ9db+RKHJSH8oDdqR8o="
+      "revision": "5b4f9c63205e5b0ef180a2b0e4cc844111f96fa6",
+      "url": "https://github.com/notashelf/nvf/archive/5b4f9c63205e5b0ef180a2b0e4cc844111f96fa6.tar.gz",
+      "hash": "sha256-YLVqyn6LpFa+h697TmZIk0qVIbe7MxMpL8UTF4K+efA="
     },
     "sops-nix": {
       "type": "Git",
@@ -272,9 +272,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "d4971dd58c6627bfee52a1ad4237637c0a2fb0cd",
-      "url": "https://github.com/Mic92/sops-nix/archive/d4971dd58c6627bfee52a1ad4237637c0a2fb0cd.tar.gz",
-      "hash": "sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M="
+      "revision": "bef289e2248991f7afeb95965c82fbcd8ff72598",
+      "url": "https://github.com/Mic92/sops-nix/archive/bef289e2248991f7afeb95965c82fbcd8ff72598.tar.gz",
+      "hash": "sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Updating inputs Sun Apr 26 06:58:35 UTC 2026




```shell
$ npins update
[blueprint] No Changes
[SPC] No Changes
[darwin] No Changes
[enthium] No Changes
[flake-aspects] No Changes
[edgevpn] No Changes
[flake-file] No Changes
[flake-parts] No Changes
[den] Changes:
-    revision: c160af184853b87cbfa1ec384cb72b53170f2f9f
+    revision: 72ac20af13abea80065db4c9247f9837a6e60e1d
-    url: https://github.com/sini/den/archive/c160af184853b87cbfa1ec384cb72b53170f2f9f.tar.gz
+    url: https://github.com/sini/den/archive/72ac20af13abea80065db4c9247f9837a6e60e1d.tar.gz
-    hash: sha256-tFldZ+PKpU/2tuU4KuYC/Uq4JE5kc4yGCLuawTAshZw=
+    hash: sha256-pgN5sWAJCWMqurI6pG7zgfFSYGy5xElQzpoGZCREies=
[import-tree] No Changes
[helium] Changes:
-    revision: 6ae2aaea1a019b8f52886041e6779919d1c1cc60
+    revision: 33dfb6d7e53e5b568690ede1e0299d2fdae56868
-    url: https://github.com/vikingnope/helium-browser-nix-flake/archive/6ae2aaea1a019b8f52886041e6779919d1c1cc60.tar.gz
+    url: https://github.com/vikingnope/helium-browser-nix-flake/archive/33dfb6d7e53e5b568690ede1e0299d2fdae56868.tar.gz
-    hash: sha256-0F+Snir+cD8HRGlf0vpvkhyjUT9HI6Qr+Z3JmUlEtSU=
+    hash: sha256-+EvL6D/ENSouidMse/QdokaHUZTgyCYmW8k6xaCqImk=
[doom-emacs] Changes:
-    revision: 5eb006f455f0558c97210ba7579880aacb045b67
+    revision: 3baa406d6596eb52e38461e6de4393f69d5cbd3a
-    url: https://github.com/doomemacs/doomemacs/archive/5eb006f455f0558c97210ba7579880aacb045b67.tar.gz
+    url: https://github.com/doomemacs/doomemacs/archive/3baa406d6596eb52e38461e6de4393f69d5cbd3a.tar.gz
-    hash: sha256-6nuelk+8qSRsh5Ryj9EpWOWXeeh/g3lI5mZsBfiFZQI=
+    hash: sha256-JPG63N+9+YRpfgaY6L6n7a0aS5SYHKYmzj+Uuu1KVQ0=
[mnw] Changes:
-    revision: 6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3
+    revision: 54f7ad6e34f4e44e0260a5140af7726a4792dece
-    url: https://github.com/Gerg-L/mnw/archive/6bd6ab9968c2432c78db4a91c9b1e84dd84fe6b3.tar.gz
+    url: https://github.com/Gerg-L/mnw/archive/54f7ad6e34f4e44e0260a5140af7726a4792dece.tar.gz
-    hash: sha256-mR8GDvGPu1QcI5Ft5lV2CIIh5Og7zRylts+XY3fa/K4=
+    hash: sha256-AHM3wNuC5zzGaygnovHqFUI0YJR1Jj7ZgK9D9m7cgMQ=
[jjui] Changes:
-    revision: f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa
+    revision: 96911e3f14b377fdb2d7c89e510c7cd558ee9098
-    url: https://github.com/idursun/jjui/archive/f8ae88c4ed82177cd5cfbecb1ed56b6919aca7fa.tar.gz
+    url: https://github.com/idursun/jjui/archive/96911e3f14b377fdb2d7c89e510c7cd558ee9098.tar.gz
-    hash: sha256-bvYeFLkt4ly0WrKUvE1QQdM3/RULSuI61DSKrTfG6+Q=
+    hash: sha256-gfZ4St30QwAO96H74fPsXG1MGDadiEIJ3jxXer0Qucs=
[nix-index-database] Changes:
-    revision: bedba5989b04614fc598af9633033b95a937933f
+    revision: b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa
-    url: https://github.com/nix-community/nix-index-database/archive/bedba5989b04614fc598af9633033b95a937933f.tar.gz
+    url: https://github.com/nix-community/nix-index-database/archive/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa.tar.gz
-    hash: sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=
+    hash: sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=
[nix-unit] Changes:
-    revision: 1c9ab50554eed0b768f9e5b6f646d63c9673f0f7
+    revision: 02e6597889281382303cbb7973748f04f2940e1a
-    url: https://github.com/nix-community/nix-unit/archive/1c9ab50554eed0b768f9e5b6f646d63c9673f0f7.tar.gz
+    url: https://github.com/nix-community/nix-unit/archive/02e6597889281382303cbb7973748f04f2940e1a.tar.gz
-    hash: sha256-hRADkHjNt41+JUHw2EiSkMaL4owL83g5ZppjYUdF/Dc=
+    hash: sha256-vZfRXBDC9FTO2Vpz8TroVMqOYqp+hcVk6Nwx6+kRN1Q=
[nixos-wsl] Changes:
-    revision: 9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911
+    revision: 4e6cad241baa0115a7aae8c55b04c166da4997c9
-    url: https://github.com/nix-community/nixos-wsl/archive/9a8c2a85f1ffdcecfb0f9c52c5a73c49ceb43911.tar.gz
+    url: https://github.com/nix-community/nixos-wsl/archive/4e6cad241baa0115a7aae8c55b04c166da4997c9.tar.gz
-    hash: sha256-LQjlc0VEn55WAT4BiI8sIsokb/2FNlcbBD+Xr3MTE24=
+    hash: sha256-0ku3gW8bZ9TTpEU2fQw86oU6ZLT2vF6pacF+cLaf7VY=
[treefmt-nix] No Changes
[home-manager] Changes:
-    revision: d401492e2acd4fea42f7705a3c266cea739c9c36
+    revision: 6f59831b23d03bbf4fbd13ad167ae25da294cc14
-    url: https://github.com/nix-community/home-manager/archive/d401492e2acd4fea42f7705a3c266cea739c9c36.tar.gz
+    url: https://github.com/nix-community/home-manager/archive/6f59831b23d03bbf4fbd13ad167ae25da294cc14.tar.gz
-    hash: sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs=
+    hash: sha256-Th3a5OZyEy4kCoyLfefnt+2dwRIrFQqYgMsayF9qzFw=
[nvf] Changes:
-    revision: 029ca6d34ad8d830afb56a9963e4baed53848da6
+    revision: 5b4f9c63205e5b0ef180a2b0e4cc844111f96fa6
-    url: https://github.com/notashelf/nvf/archive/029ca6d34ad8d830afb56a9963e4baed53848da6.tar.gz
+    url: https://github.com/notashelf/nvf/archive/5b4f9c63205e5b0ef180a2b0e4cc844111f96fa6.tar.gz
-    hash: sha256-N/I4lxWjes7E8n4NEOYaNxxvJ9db+RKHJSH8oDdqR8o=
+    hash: sha256-YLVqyn6LpFa+h697TmZIk0qVIbe7MxMpL8UTF4K+efA=
[trix] No Changes
[vscode-server] No Changes
[sops-nix] Changes:
-    revision: d4971dd58c6627bfee52a1ad4237637c0a2fb0cd
+    revision: bef289e2248991f7afeb95965c82fbcd8ff72598
-    url: https://github.com/Mic92/sops-nix/archive/d4971dd58c6627bfee52a1ad4237637c0a2fb0cd.tar.gz
+    url: https://github.com/Mic92/sops-nix/archive/bef289e2248991f7afeb95965c82fbcd8ff72598.tar.gz
-    hash: sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M=
+    hash: sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI=
[with-inputs] No Changes
[nixpkgs] Changes:
-    revision: 566acc07c54dc807f91625bb286cb9b321b5f42a
+    revision: 01fbdeef22b76df85ea168fbfe1bfd9e63681b30
-    url: https://github.com/nixos/nixpkgs/archive/566acc07c54dc807f91625bb286cb9b321b5f42a.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/01fbdeef22b76df85ea168fbfe1bfd9e63681b30.tar.gz
-    hash: sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=
+    hash: sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=
[INFO ] Update successful.
```




request-checks: true
